### PR TITLE
Always fail when a policy doesn't provide `validate_settings`

### DIFF
--- a/crates/policy-evaluator/src/policy_evaluator.rs
+++ b/crates/policy-evaluator/src/policy_evaluator.rs
@@ -155,27 +155,13 @@ impl PolicyEvaluator {
                     message: Some(format!("error: {:?}", e)),
                 })
             }
-            Err(err) => {
-                if let wapc::errors::ErrorKind::GuestCallFailure(m) = err.kind() {
-                    // Unfortunately waPC doesn't define a dedicated error
-                    if m.contains("No handler registered") || m.contains("Could not find function")
-                    {
-                        return SettingsValidationResponse {
-                            valid: true,
-                            message: Some(String::from(
-                                "This policy doesn't have a settings validation capability",
-                            )),
-                        };
-                    }
-                };
-                SettingsValidationResponse {
-                    valid: false,
-                    message: Some(format!(
-                        "Error invoking settings validation callback: {:?}",
-                        err
-                    )),
-                }
-            }
+            Err(err) => SettingsValidationResponse {
+                valid: false,
+                message: Some(format!(
+                    "Error invoking settings validation callback: {:?}",
+                    err
+                )),
+            },
         }
     }
 }


### PR DESCRIPTION
Unfortunately waPC doesn't provide a specific error message when the host tries to call a non-existent function.

Parsing the error message returned by the waPC host library is highly unreliable: it turns out the error string is generated by the waPC guest SDK. That means each language, and each version of the language SDK, can generate a completely different error message.

This commit enforces all the policies to provide a `validate_settings` callback.