### PR TITLE
Update to latest version of kubewarden's client SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90cc0916297663741bb45b0b90bdb5cdb7645958bbcbca98f8ff665b40651a1"
+checksum = "5f6a07292089c1ed973b2268c3601049b8af03d740829837c9fe2b9e158248d2"
 dependencies = [
  "anyhow",
  "k8s-openapi",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ async-stream = "0.3.0"
 async-trait = "0.1.42"
 base64 = "0.13.0"
 policy-evaluator = { path = "crates/policy-evaluator" }
-kubewarden-policy-sdk = "0.1.0"
+kubewarden-policy-sdk = "0.2.0"
 clap = "2.33.3"
 futures-util = "0.3.12"
 kube = "0.51.0"

--- a/crates/policy-evaluator/Cargo.toml
+++ b/crates/policy-evaluator/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.13.0"
-kubewarden-policy-sdk = "0.1.0"
+kubewarden-policy-sdk = "0.2.0"
 hyper = { version = "0.14" }
 json-patch = "0.2.6"
 kube = "0.51.0"

--- a/crates/policy-evaluator/src/validation_response.rs
+++ b/crates/policy-evaluator/src/validation_response.rs
@@ -55,9 +55,7 @@ impl ValidationResponse {
         pol_val_resp: &PolicyValidationResponse,
     ) -> Result<ValidationResponse> {
         let patch = match pol_val_resp.mutated_object.clone() {
-            Some(mut_obj_str) => {
-                let mut_obj = serde_json::from_str(mut_obj_str.as_str())
-                    .map_err(|e| anyhow!("cannot deserialize mutated object: {:?}", e))?;
+            Some(mut_obj) => {
                 let diff = json_patch::diff(req_obj, &mut_obj);
                 let empty_patch = json_patch::Patch(Vec::<json_patch::PatchOperation>::new());
                 if diff == empty_patch {
@@ -167,7 +165,7 @@ mod tests {
             accepted: true,
             message: None,
             code: None,
-            mutated_object: Some(serde_json::to_string(&req_obj).unwrap()),
+            mutated_object: Some(req_obj.clone()),
         };
 
         let response = ValidationResponse::from_policy_validation_response(
@@ -199,7 +197,7 @@ mod tests {
             accepted: true,
             message: None,
             code: None,
-            mutated_object: Some(serde_json::to_string(&mutated_obj).unwrap()),
+            mutated_object: Some(mutated_obj),
         };
 
         let response = ValidationResponse::from_policy_validation_response(


### PR DESCRIPTION
This is needed to support policies written with v0.2.0 of the SDK

Once this is merged I'll tag a new release of policy-server