### PR TITLE
Fix the release pipeline of `policy-testdrive`

### DIFF
--- a/.github/workflows/testdrive-release.yml
+++ b/.github/workflows/testdrive-release.yml
@@ -23,8 +23,7 @@ jobs:
 
     - name: Compress binary
       run: |
-        mv target/x86_64-unknown-linux-musl/release/${{ env.BINARY_NAME }} ${{ env.BINARY_FULL_NAME }}
-        zip -9 ${{ env.BINARY_FULL_NAME }}.zip ${{ env.BINARY_FULL_NAME }}
+        zip -9j ${{ env.BINARY_NAME }}.zip target/x86_64-unknown-linux-musl/release/${{ env.BINARY_NAME }}
 
     - name: Create Release
       id: create_release


### PR DESCRIPTION
Fix the release action of policy-testdrive by ensuring the linux binary is properly compressed.
    
This fixes issue #47
