### PR TITLE
opa: read policy execution mode when setting up the policy evaluator

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2,7 +2,10 @@ use crate::communication::EvalRequest;
 use crate::settings::Policy;
 use crate::utils::convert_yaml_map_to_json;
 use anyhow::{anyhow, Result};
-use policy_evaluator::policy_evaluator::{PolicyEvaluator, PolicyExecutionMode, ValidateRequest};
+use policy_evaluator::{
+    policy_evaluator::{PolicyEvaluator, ValidateRequest},
+    policy_metadata::Metadata,
+};
 use std::collections::HashMap;
 use tokio::sync::mpsc::Receiver;
 use tracing::{error, info_span};
@@ -35,11 +38,14 @@ impl Worker {
                     }
                 });
 
-            let mut policy_evaluator = PolicyEvaluator::from_file(
+            let policy_contents = std::fs::read(&policy.wasm_module_path)?;
+            let policy_metadata = Metadata::from_contents(policy_contents.clone())?;
+            let policy_execution_mode = policy_metadata.unwrap_or_default().execution_mode;
+
+            let mut policy_evaluator = PolicyEvaluator::from_contents(
                 id.to_string(),
-                &policy.wasm_module_path,
-                // TODO (ereslibre): choose based on metadata
-                PolicyExecutionMode::KubewardenWapc,
+                policy_contents,
+                policy_execution_mode,
                 settings_json,
             )?;
 


### PR DESCRIPTION
Fixes: https://github.com/kubewarden/policy-server/issues/76

When reading the policy and constructing a policy evaluator for it,
read the runtime annotation on the policy metadata and honor it. If
this annotation is present, fallback to the default settings of the
runtime: currently the Kubewarden Wapc backend.