### PR TITLE
Fix opentelemetry otlp integration

### DIFF
--- a/otel-collector-minimal-config.yaml
+++ b/otel-collector-minimal-config.yaml
@@ -1,0 +1,31 @@
+# This is the minimal configuration to start a OpenTelemetry collector
+# that collects traces via the otlp protocol, and then sends them via
+# batches to a central jaeger collector
+#
+# A simple otel-collector instance can be started in this way:
+#
+#   docker run --rm -p 4317:4317 \
+#     -v `pwd`/otel-collector-minimal-config.yaml:/etc/otel/config.yaml:ro \
+#     otel/opentelemetry-collector-dev:latest
+#
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  batch:
+
+exporters:
+  jaeger:
+    # TODO: change the IP address with the IP/FQDN of your jaeger endpoint
+    endpoint: "192.168.122.77:14250"
+    insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger]


### PR DESCRIPTION
This PR fixes the integration with opentelemetry otlp collector. When we updated the project dependencies we introduced 2 regressions:

1. The name of the service was not propagated by the otlp collector to other endpoints/collector
2. opentelemetry was not sending traces in batch mode. This is the recommended way for production deployments, otherwise the performance of the whole application will be affected by trace propagation

Finally, the PR adds a sample configuration file of otlp collector receiving events from policy-server and then sending them to a jaeger endpoint