### PR TITLE
Abort execution if any policy has missing Rego builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 [[package]]
 name = "burrego"
 version = "0.1.1"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.0#01548909206cbbc6ce8cf7321ca3596aa72cfb9b"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.1#f822307cec22b3583c76300a1f814fe3fb6e7384"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -327,6 +327,7 @@ dependencies = [
  "clap",
  "gtmpl",
  "gtmpl_value",
+ "itertools",
  "json-patch",
  "lazy_static",
  "regex",
@@ -2051,8 +2052,8 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.2.0"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.0#01548909206cbbc6ce8cf7321ca3596aa72cfb9b"
+version = "0.2.1"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.1#f822307cec22b3583c76300a1f814fe3fb6e7384"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-server"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 anyhow = "1.0"
 async-stream = "0.3.0"
 itertools = "0.10.1"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.0" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.1" }
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.13" }
 kubewarden-policy-sdk = "0.2.4"
 lazy_static = "1.4.0"

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -60,7 +60,7 @@ impl WorkerPool {
                                     error!(error = e.to_string().as_str(), "cannot spawn worker");
                                     canary.store(false, Ordering::SeqCst);
                                     b.wait();
-                                    return Err(anyhow!("Worker {} couldn't start: {:?}", n, e));
+                                    return Err(anyhow!("Worker {} couldn't start: {}", n, e));
                                 }
                             };
                             b.wait();


### PR DESCRIPTION
Fixes:https://github.com/kubewarden/policy-server/issues/86

If any Rego policy refers to an unimplemented builtin, abort the execution of the whole policy-server.