### PR TITLE
Tracing improvements

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,8 @@ lazy_static! {
             builtins,
         )
     };
+    pub(crate) static ref HOSTNAME: String =
+        std::env::var("HOSTNAME").unwrap_or_else(|_| String::from("unknown"));
 }
 
 pub(crate) fn build_cli() -> App<'static, 'static> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,6 +161,7 @@ pub(crate) fn setup_tracing(matches: &clap::ArgMatches) -> Result<()> {
         .add_directive("cranelift_wasm=off".parse().unwrap())
         .add_directive("regalloc=off".parse().unwrap())
         .add_directive("hyper=off".parse().unwrap())
+        .add_directive("h2=off".parse().unwrap())
         .add_directive("tower=off".parse().unwrap());
 
     match matches.value_of("log-fmt").unwrap_or_default() {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -30,7 +30,11 @@ impl fmt::Display for PolicyErrors {
 }
 
 impl Worker {
-    #[tracing::instrument(name = "worker_new", skip(rx, policies))]
+    #[tracing::instrument(
+        name = "worker_new",
+        fields(host=crate::cli::HOSTNAME.as_str()),
+        skip_all,
+    )]
     pub(crate) fn new(
         rx: Receiver<EvalRequest>,
         policies: HashMap<String, Policy>,


### PR DESCRIPTION
Improve the tracing experience: add the hostname of the machine (or Pod) as part of the tags. This makes possible to find all the trace events generated by a certain deployment of policy-server.

Also, remove some unwanted debug statements from the stdout.