### PR TITLE
Enrich tracing with extra AdmissionReview fields.

### DIFF
--- a/src/admission_review.rs
+++ b/src/admission_review.rs
@@ -1,9 +1,37 @@
 use anyhow::{anyhow, Result};
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct GroupVersionKind {
+    pub group: String,
+    pub version: String,
+    pub kind: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct GroupVersionResource {
+    pub group: String,
+    pub version: String,
+    pub resource: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct AdmissionReview {
-    pub request: serde_json::Value,
     pub uid: String,
+    pub kind: GroupVersionKind,
+    pub resource: GroupVersionResource,
+    pub sub_resource: Option<String>,
+    pub request_kind: Option<GroupVersionKind>,
+    pub request_resource: Option<GroupVersionResource>,
+    pub request_sub_resource: Option<String>,
+    pub name: Option<String>,
+    pub namespace: Option<String>,
+    pub operation: String,
+    pub user_info: k8s_openapi::api::authentication::v1::UserInfo,
+    pub object: Option<k8s_openapi::apimachinery::pkg::runtime::RawExtension>,
+    pub old_object: Option<k8s_openapi::apimachinery::pkg::runtime::RawExtension>,
+    pub dry_run: Option<bool>,
+    pub options: Option<k8s_openapi::apimachinery::pkg::runtime::RawExtension>,
 }
 
 impl AdmissionReview {
@@ -17,18 +45,8 @@ impl AdmissionReview {
             Some(req) => req,
             None => return Err(anyhow!("Cannot parse AdmissionReview: 'request' not found")),
         };
-
-        let uid = match req.get("uid") {
-            Some(u) => u
-                .as_str()
-                .ok_or_else(|| anyhow!("Cannot convert uid to string")),
-            None => Err(anyhow!("Cannot parse AdmissionReview: 'uid' not found")),
-        }?;
-
-        Ok(AdmissionReview {
-            request: req.clone(),
-            uid: String::from(uid),
-        })
+        let admission_review: AdmissionReview = serde_json::from_value(req.clone())?;
+        Ok(admission_review)
     }
 }
 
@@ -36,6 +54,7 @@ impl AdmissionReview {
 mod tests {
     use super::*;
     use hyper::body::Bytes;
+    use std::collections::BTreeMap;
 
     #[test]
     fn invalid_input() {
@@ -80,7 +99,29 @@ mod tests {
             { 
                 "request": {
                     "uid": "hello",
-                    "foo": "bar"
+                    "foo": "bar",
+
+                    "kind": {"group":"autoscaling","version":"v1","kind":"Scale"},
+                    "resource": {"group":"apps","version":"v1","resource":"deployments"},
+                    "subResource": "scale",
+                    "requestKind": {"group":"autoscaling","version":"v1","kind":"Scale"},
+                    "requestResource": {"group":"apps","version":"v1","resource":"deployments"},
+                    "requestSubResource": "scale",
+                    "name": "my-deployment",
+                    "namespace": "my-namespace",
+                    "operation": "UPDATE",
+                    "userInfo": {
+                      "username": "admin",
+                      "uid": "014fbff9a07c",
+                      "groups": ["system:authenticated","my-admin-group"],
+                      "extra": {
+                        "some-key":["some-value1", "some-value2"]
+                      }
+                    },
+                    "object": {"apiVersion":"autoscaling/v1","kind":"Scale"},
+                    "oldObject": {"apiVersion":"autoscaling/v1","kind":"Scale"},
+                    "options": {"apiVersion":"meta.k8s.io/v1","kind":"UpdateOptions"},
+                    "dryRun": false
                 }
             }
         "#,
@@ -91,5 +132,69 @@ mod tests {
 
         let ar = res.unwrap();
         assert_eq!(ar.uid, "hello");
+        assert_eq!(ar.name.unwrap(), "my-deployment");
+        assert_eq!(ar.namespace.unwrap(), "my-namespace");
+        assert_eq!(ar.operation, "UPDATE");
+        assert_eq!(ar.sub_resource.unwrap(), "scale");
+        assert_eq!(ar.kind.group, "autoscaling");
+        assert_eq!(ar.kind.version, "v1");
+        assert_eq!(ar.kind.kind, "Scale");
+        assert_eq!(ar.resource.resource, "deployments");
+        assert_eq!(ar.resource.group, "apps");
+        assert_eq!(ar.resource.version, "v1");
+        assert_eq!(ar.resource.version, "v1");
+
+        assert!(!ar.dry_run.unwrap());
+        assert_eq!(ar.request_sub_resource.unwrap(), "scale");
+        assert!(ar.request_kind.is_some());
+        let request_kind = ar.request_kind.unwrap();
+        assert_eq!(request_kind.group, "autoscaling");
+        assert_eq!(request_kind.version, "v1");
+        assert_eq!(request_kind.kind, "Scale");
+        assert!(ar.request_resource.is_some());
+        let request_resource = ar.request_resource.unwrap();
+        assert_eq!(request_resource.group, "apps");
+        assert_eq!(request_resource.version, "v1");
+        assert_eq!(request_resource.resource, "deployments");
+
+        assert_eq!(ar.user_info.username.unwrap(), "admin");
+        assert_eq!(ar.user_info.uid.unwrap(), "014fbff9a07c");
+        assert_eq!(
+            ar.user_info.groups.unwrap(),
+            vec!["system:authenticated", "my-admin-group"]
+        );
+        let mut expected_extra_values = BTreeMap::new();
+        expected_extra_values.insert(
+            String::from("some-key"),
+            vec![String::from("some-value1"), String::from("some-value2")],
+        );
+        assert_eq!(ar.user_info.extra.unwrap(), expected_extra_values);
+
+        assert!(ar.object.is_some());
+        let object = ar.object.unwrap();
+        assert_eq!(
+            object.0.get("apiVersion").unwrap().as_str().unwrap(),
+            "autoscaling/v1"
+        );
+        assert_eq!(object.0.get("kind").unwrap().as_str().unwrap(), "Scale");
+
+        assert!(ar.old_object.is_some());
+        let old_object = ar.old_object.unwrap();
+        assert_eq!(
+            old_object.0.get("apiVersion").unwrap().as_str().unwrap(),
+            "autoscaling/v1"
+        );
+        assert_eq!(old_object.0.get("kind").unwrap().as_str().unwrap(), "Scale");
+
+        assert!(ar.options.is_some());
+        let options = ar.options.unwrap();
+        assert_eq!(
+            options.0.get("apiVersion").unwrap().as_str().unwrap(),
+            "meta.k8s.io/v1"
+        );
+        assert_eq!(
+            options.0.get("kind").unwrap().as_str().unwrap(),
+            "UpdateOptions"
+        );
     }
 }

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -3,12 +3,13 @@ use policy_evaluator::validation_response::ValidationResponse;
 use std::collections::HashMap;
 use tokio::sync::oneshot;
 
+use crate::admission_review::AdmissionReview;
 use crate::settings::Policy;
 
 #[derive(Debug)]
 pub(crate) struct EvalRequest {
     pub policy_id: String,
-    pub req: serde_json::Value,
+    pub req: AdmissionReview,
     pub resp_chan: oneshot::Sender<Option<ValidationResponse>>,
     pub parent_span: tracing::Span,
 }


### PR DESCRIPTION
Updates the parent span in the policy server adding more fields from the AdimissionReview enriching the traces.

Closes #94 