### PR TITLE
Remove jaeger integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,31 +1098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
-name = "headers"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
-dependencies = [
- "base64 0.13.0",
- "bitflags",
- "bytes 1.1.0",
- "headers-core",
- "http 0.2.4",
- "mime",
- "sha-1",
- "time",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http 0.2.4",
-]
-
-[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,12 +1283,6 @@ checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "integer-encoding"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
 name = "io-lifetimes"
@@ -1848,39 +1817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50ceb0b0e8b75cb3e388a2571a807c8228dabc5d6670f317b6eb21301095373"
-dependencies = [
- "async-trait",
- "bytes 1.1.0",
- "futures-util",
- "http 0.2.4",
- "opentelemetry",
- "reqwest",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db22f492873ea037bc267b35a0e8e4fb846340058cb7c864efe3d0bf23684593"
-dependencies = [
- "async-trait",
- "headers",
- "http 0.2.4",
- "lazy_static",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions",
- "reqwest",
- "thiserror",
- "thrift",
- "tokio",
-]
-
-[[package]]
 name = "opentelemetry-otlp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,24 +1831,6 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeac823339e8b0f27b961f4385057bf9f97f2863bc745bd015fd6091f2270e9"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
-name = "ordered-float"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2114,7 +2032,6 @@ dependencies = [
  "num_cpus",
  "openssl",
  "opentelemetry",
- "opentelemetry-jaeger",
  "opentelemetry-otlp",
  "policy-evaluator",
  "policy-fetcher",
@@ -2642,7 +2559,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.8.0",
+ "ordered-float",
  "serde",
 ]
 
@@ -2691,19 +2608,6 @@ dependencies = [
  "indexmap",
  "serde",
  "yaml-rust",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer",
- "cfg-if",
- "cpufeatures",
- "digest",
- "opaque-debug",
 ]
 
 [[package]]
@@ -2891,28 +2795,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "log",
- "ordered-float 1.1.1",
- "threadpool",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,5 @@ tracing = "0.1"
 tracing-subscriber = { version= "0.2", features = ["fmt"] }
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.15.0"
-opentelemetry-jaeger = { version = "*", features = ["reqwest_collector_client", "rt-tokio"] }
 opentelemetry = { version = "*", default-features = false, features = ["trace", "rt-tokio"] }
 opentelemetry-otlp = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -86,41 +86,6 @@ flag is used to choose the format to be used.
 By default, log messages are printed on the standard output using the
 `text` format. Logs can be printed as JSON objects using the `json` format type.
 
-### Jaeger
-
-[Jaeger](https://www.jaegertracing.io/) is an open souce distributed tracing
-solution.
-
-Policy server can send trace events directly to a Jaeger collector using the
-`--log-fmt jaeger` flag.
-
-Underneat, policy server relies on [Open Telemetry](https://github.com/open-telemetry/opentelemetry-rust)
-to send events to the Jaeger collector.
-
-By default, events are sent to a collector listening on localhost. However, 
-additional Jaeger settings can be specified via [these environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#jaeger-exporter):
-
-| Name                            | Description                                                      | Default                                                                                          |
-|---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                                    | "localhost"                                                                                      |
-| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent                                        | 6832                                                                                             |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                                  | <!-- markdown-link-check-disable --> "http://localhost:14250"<!-- markdown-link-check-enable --> |
-| OTEL_EXPORTER_JAEGER_TIMEOUT    | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                                                              |
-| OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication                | -                                                                                                |
-| OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication                | -                                                                                                |
-
-A quick evaluation of Jaeger can be done using its "all-in-one" container
-image.
-
-The image can be started via:
-```console
-docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
-```
-
-**Note well:** this Jaeger deployment is not meant for production. Please
-take a look at [Jaeger's official documentation](https://www.jaegertracing.io/docs/)
-for more details.
-
 ### Open Telemetry Collector
 
 The open Telemetry project provides a [collector](https://opentelemetry.io/docs/collector/)
@@ -140,6 +105,9 @@ Current limitations:
   * Policy server doesn't expose any configuration setting for Open Telemetry
     (e.g.: endpoint URL, encryption, authentication,...). All of the tuning
     has to be done on the collector process that runs as a sidecar.
+
+More details about OpenTelemetry and tracing can be found inside of
+our [official docs](https://docs.kubewarden.io/operator-manual/tracing/01-quickstart.html).
 
 # Building
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,7 +48,7 @@ pub(crate) fn build_cli() -> App<'static, 'static> {
                 .long("log-fmt")
                 .env("KUBEWARDEN_LOG_FMT")
                 .default_value("text")
-                .possible_values(&["text", "json", "jaeger", "otlp"])
+                .possible_values(&["text", "json", "otlp"])
                 .help("Log output format"),
         )
         .arg(
@@ -173,23 +173,6 @@ pub(crate) fn setup_tracing(matches: &clap::ArgMatches) -> Result<()> {
             .with(filter_layer)
             .with(fmt::layer())
             .init(),
-        "jaeger" => {
-            // Create a new OpenTelemetry pipeline sending events
-            // to a jaeger instance
-            // The Jaeger exporter can be configerd via environment
-            // variables (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#jaeger-exporter)
-            let tracer = opentelemetry_jaeger::new_pipeline()
-                .with_service_name(SERVICE_NAME)
-                .install_batch(opentelemetry::runtime::Tokio)?;
-
-            // Create a tracing layer with the configured tracer
-            let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-            tracing_subscriber::registry()
-                .with(filter_layer)
-                .with(telemetry)
-                .with(fmt::layer())
-                .init()
-        }
         "otlp" => {
             // Create a new OpenTelemetry pipeline sending events to a
             // OpenTelemetry collector using the OTLP format.

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
     // This is the channel used to have the asynchronous code trigger the
     // bootstrap of the worker pool. The bootstrap must be triggered
     // from within the asynchronous code because some of the tracing collectors
-    // (e.g. jaeger, OpenTelemetry) require a tokio::Runtime to be available.
+    // (e.g. OpenTelemetry) require a tokio::Runtime to be available.
     let (worker_pool_bootstrap_req_tx, worker_pool_bootstrap_req_rx) =
         oneshot::channel::<WorkerPoolBootRequest>();
 
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
     // This is the channel used to have the asynchronous code trigger the
     // bootstrap of the kubernetes poller. The bootstrap must be triggered
     // from within the asynchronous code because some of the tracing collectors
-    // (e.g. jaeger, OpenTelemetry) require a tokio::Runtime to be available.
+    // (e.g. OpenTelemetry) require a tokio::Runtime to be available.
     let (kube_poller_bootstrap_req_tx, kube_poller_bootstrap_req_rx) =
         oneshot::channel::<KubePollerBootRequest>();
 


### PR DESCRIPTION
Do not send traces to a Jaeger collector in a direct fashion. We've agreed to rely on the OpenTelemetry collector for that.