### PR TITLE
Handle the new sources.yaml format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,8 +1994,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.1.14"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.14#52277963c3bc47530d8724ddcfb01301535b50cb"
+version = "0.1.15"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.15#3ae53aecd00175951ff7e3f25af76361a9ce4c83"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0"
 async-stream = "0.3.0"
 itertools = "0.10.1"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.1" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.14" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.15" }
 kubewarden-policy-sdk = "0.2.4"
 lazy_static = "1.4.0"
 clap = "2.33.3"


### PR DESCRIPTION
Update the `policy-fectcher` crate to allow users to specify certificates into the `sources.yaml` file.

This is required by the kubewarden controller.
