### PR TITLE
feat: report loaded policies on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,8 +2165,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.1.16"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.17#69319a2d75f5065ac983dc175a0665c89c86b89e"
+version = "0.1.18"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.1.18#2e8c86129e796cd9f24f0c8744be3bddc4b8a96f"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0"
 async-stream = "0.3.0"
 itertools = "0.10.1"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.3" }
-policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.17" }
+policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.1.18" }
 kubewarden-policy-sdk = "0.2.4"
 lazy_static = "1.4.0"
 clap = "2.33.3"


### PR DESCRIPTION
Fixes: https://github.com/kubewarden/policy-server/issues/88

The reported information includes:

- The name that was given to the policy in the configuration
- The SHA-256 sum of the policy itself
- Whether the policy is mutating or not