### PR TITLE
chore: pin base64ct to 1.1.1 version for Rust Edition 2018

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,8 +271,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "base64ct"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
+source = "git+https://github.com/RustCrypto/formats.git?tag=base64ct/v1.1.1#c4982b74e21e7e3d0ca1101cc5e37eeb7fc0fd07"
 
 [[package]]
 name = "bincode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,9 @@ tracing = "0.1"
 tracing-subscriber = { version= "0.2", features = ["fmt"] }
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.15.0"
+
+[patch.crates-io]
+# Forcing base64ct to version 1.1.1 given that version 1.2.0 has been
+# bumped to use Rust 2021 edition. When we see is time, we can bump as
+# well, but for now, pin to 1.1.1 that is bound to edition 2018.
+base64ct = { git = "https://github.com/RustCrypto/formats.git", tag = "base64ct/v1.1.1" }


### PR DESCRIPTION
A newer version of base64ct (1.2.x) is bumped to Rust Edition
2021. Keep a pinned version to 1.1.1 of base64ct that did depend on
Rust Edition 2018.

We can get rid of this when we are ready to move to Edition 2021.