### PR TITLE
chore: add cargo audit configuration

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,11 @@
+[advisories]
+ignore = [
+  "RUSTSEC-2020-0071", # `time` localtime_r segfault -- https://rustsec.org/advisories/RUSTSEC-2020-0071
+                       # Ignored because there are not known workarounds or dependency version bump
+                       # at this time. The call to localtime_r is not protected by any lock and can
+                       # cause unsoundness. Read the previous link for more information.
+  "RUSTSEC-2020-0159", # `chrono` localtime_r segfault -- https://rustsec.org/advisories/RUSTSEC-2020-0159
+                       # Ignored because there are not known workarounds or dependency version bump
+                       # at this time. The call to localtime_r is not protected by any lock and can
+                       # cause unsoundness. Read the previous link for more information.
+]


### PR DESCRIPTION
By adding a cargo audit configuration we are able to ignore security
advisories that don't apply.

Related: https://github.com/kubewarden/policy-server/issues/110