### PR TITLE
feat: Sigstore verification of policies on download

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "policy-server"
 version = "0.2.5"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
-  "Rafael Fernández López <rfernandezlopez@suse.com>"
+  "Rafael Fernández López <rfernandezlopez@suse.com>",
+  "Víctor Cuadrado Juan <vcuadradojuan@suse.de>"
 ]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For example, given the configuration file from above, the `namespace_simple` pol
 will be invoked with the `valid_namespace` parameter set to `kubewarden-approved`.
 
 Note well: it's possible to expose the same policy multiple times, each time with
-a different set of paraments.
+a different set of parameters.
 
 The Wasm file providing the Kubewarden Policy can be either loaded from
 the local filesystem or it can be fetched from a remote location. The behaviour
@@ -76,7 +76,7 @@ depends on the URL format provided by the user:
 
 The verbosity of policy-server can be configured via the `--log-level` flag.
 The default log level used is `info`, but `trace`, `debug`, `warn` and `error`
-levels are availble too.
+levels are available too.
 
 Policy server can produce logs events using different formats. The `--log-fmt`
 flag is used to choose the format to be used.
@@ -111,12 +111,11 @@ our [official docs](https://docs.kubewarden.io/operator-manual/tracing/01-quicks
 
 # Building
 
-You can either build `kubewarden-admission` from sources (see below) or you can
-use the container image we maintain inside of our
+You can use the container image we maintain inside of our
 [GitHub Container Registry](https://github.com/orgs/kubewarden/packages/container/package/policy-server).
 
-The `policy-server` binary can be built in this way:
+Alternatively, the `policy-server` binary can be built in this way:
 
 ```shell
-$ cargo build
+$ make build
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,7 +114,6 @@ pub(crate) fn build_cli() -> App<'static, 'static> {
                 .env("KUBEWARDEN_VERIFICATION_CONFIG_PATH")
                 .long("verification-path")
                 .default_value("verification.yml")
-                // .takes_value(true)
                 .help("YAML file holding verification information (URIs, keys, annotations...)"),
         )
         .arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::settings::{read_policies_file, Policy};
+use crate::settings::{read_policies_file, read_verification_file, Policy, VerificationSettings};
 use anyhow::{anyhow, Result};
 use clap::{crate_authors, crate_description, crate_name, crate_version, App, Arg};
 use itertools::Itertools;
@@ -110,6 +110,14 @@ pub(crate) fn build_cli() -> App<'static, 'static> {
                 .help("YAML file holding source information (https, registry insecure hosts, custom CA's...)"),
         )
         .arg(
+            Arg::with_name("verification-path")
+                .env("KUBEWARDEN_VERIFICATION_CONFIG_PATH")
+                .long("verification-path")
+                .default_value("verification.yml")
+                // .takes_value(true)
+                .help("YAML file holding verification information (URIs, keys, annotations...)"),
+        )
+        .arg(
             Arg::with_name("docker-config-json-path")
                 .env("KUBEWARDEN_DOCKER_CONFIG_JSON_PATH")
                 .long("docker-config-json-path")
@@ -121,7 +129,14 @@ pub(crate) fn build_cli() -> App<'static, 'static> {
                 .long("enable-metrics")
                 .required(false)
                 .takes_value(false)
-                .help("Enable metrics"),
+                .help("Enable metrics [env: KUBEWARDEN_ENABLE_METRICS=]"),
+        )
+        .arg(
+            Arg::with_name("enable-verification")
+                .long("enable-verification")
+                .required(false)
+                .takes_value(false)
+                .help("Enable Sigstore verification [env: KUBEWARDEN_ENABLE_VERIFICATION=]"),
         )
         .long_version(VERSION_AND_BUILTINS.as_str())
 }
@@ -155,6 +170,27 @@ pub(crate) fn policies(matches: &clap::ArgMatches) -> Result<HashMap<String, Pol
             e
         )
     })
+}
+
+pub(crate) fn verification_settings(matches: &clap::ArgMatches) -> Result<VerificationSettings> {
+    let verification_file = Path::new(matches.value_of("verification-path").unwrap_or("."));
+    match read_verification_file(verification_file) {
+        Err(e) => Err(anyhow!(
+            "error while loading verification info from {:?}: {}",
+            verification_file,
+            e
+        )),
+        Ok(vs) => {
+            if vs.verification_keys.is_empty() {
+                Err(anyhow!(
+                    "error while loading verification info from {:?}: contains 0 verification keys",
+                    verification_file,
+                ))
+            } else {
+                Ok(vs)
+            }
+        }
+    }
 }
 
 // Setup the tracing system. This MUST be done inside of a tokio Runtime

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,10 +64,11 @@ fn main() -> Result<()> {
     let verify_enabled = matches.is_present("enable-verification")
         || std::env::var_os("KUBEWARDEN_ENABLE_VERIFICATION").is_some();
 
-    let mut verification_settings: Option<VerificationSettings> = None;
-    if verify_enabled {
-        verification_settings = Some(cli::verification_settings(&matches)?);
-    }
+    let verification_settings: Option<VerificationSettings> = if verify_enabled {
+        Some(cli::verification_settings(&matches)?)
+    } else {
+        None
+    };
 
     ////////////////////////////////////////////////////////////////////////////
     //                                                                        //
@@ -223,7 +224,7 @@ fn main() -> Result<()> {
                         if verified_manifest_digest.is_none() {
                             // when deserializing keys we check that have keys to
                             // verify. We will always have a digest manifest
-                            fatal_error("Trying to verify but no keys were passed".to_string());
+                            fatal_error("Verification of policy failed".to_string());
                             unreachable!();
                         }
                         verifier

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,27 @@ fn main() -> Result<()> {
             .expect("error parsing the number of workers")
     });
 
+    // As of clap version 2, we have to do this check in separate
+    // steps.
+    //
+    // `--enable-metrics` does not take a value. However, using
+    // `env` from clap to link the `KUBEWARDEN_ENABLE_METRICS`
+    // envvar to this flag forcefully sets `takes_value` on the
+    // flag, making the usage of `--enable-metrics` argument weird
+    // (this should not take a value).
+    //
+    // The answer is therefore, to just set up the
+    // `--enable-metrics` flag in clap, and check manually whether
+    // the environment variable is set.
+    //
+    // The same is true for `--verify-policies` flag, and
+    // KUBEWARDEN_ENABLE_VERIFICATION env var.
+    //
+    // Check https://github.com/clap-rs/clap/issues/1476 for
+    // further details.
+    let metrics_enabled = matches.is_present("enable-metrics")
+        || std::env::var_os("KUBEWARDEN_ENABLE_METRICS").is_some();
+
     ////////////////////////////////////////////////////////////////////////////
     //                                                                        //
     // Phase 1: setup the Wasm worker pool, this "lives" inside of a          //
@@ -120,23 +141,6 @@ fn main() -> Result<()> {
             fatal_error(err.to_string());
         }
 
-        // As of clap version 2, we have to do this check in separate
-        // steps.
-        //
-        // `--enable-metrics` does not take a value. However, using
-        // `env` from clap to link the `KUBEWARDEN_ENABLE_METRICS`
-        // envvar to this flag forcefully sets `takes_value` on the
-        // flag, making the usage of `--enable-metrics` argument weird
-        // (this should not take a value).
-        //
-        // The answer is therefore, to just set up the
-        // `--enable-metrics` flag in clap, and check manually whether
-        // the environment variable is set.
-        //
-        // Check https://github.com/clap-rs/clap/issues/1476 for
-        // further details.
-        let metrics_enabled = matches.is_present("enable-metrics")
-            || std::env::var_os("KUBEWARDEN_ENABLE_METRICS").is_some();
 
         // The unused variable is required so the meter is not dropped early and
         // lives for the whole block lifetime, exporting metrics

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,7 @@ fn main() -> Result<()> {
                         if verified_manifest_digest.is_none() {
                             // when deserializing keys we check that have keys to
                             // verify. We will always have a digest manifest
+                            fatal_error("Trying to verify but no keys were passed".to_string());
                             unreachable!();
                         }
                         verifier

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -36,6 +36,18 @@ pub fn read_policies_file(path: &Path) -> Result<HashMap<String, Policy>> {
     Ok(ps)
 }
 
+#[derive(Deserialize, Debug, Clone)]
+pub struct VerificationSettings {
+    pub verification_keys: HashMap<String, String>,
+    pub verification_annotations: Option<HashMap<String, String>>,
+}
+
+pub fn read_verification_file(path: &Path) -> Result<VerificationSettings> {
+    let settings_file = File::open(path)?;
+    let vs: VerificationSettings = serde_yaml::from_reader(&settings_file)?;
+    Ok(vs)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/verification.yml.example
+++ b/verification.yml.example
@@ -1,0 +1,15 @@
+---
+verification_keys:
+  key-name-irrelevant: |
+            -----BEGIN PUBLIC KEY-----
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEX0HFTtCfTtPmkx5p1RbtwDE1EVzu
+            wjQs1cCRKb5Pz/yUspkQsN3FO4iyWodCy5j3o0CdIJD/1gvq98pf4IG9tA==
+            -----END PUBLIC KEY-----
+  another-key: |
+            -----BEGIN PUBLIC KEY-----
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEX0HFTtCfTtPmkx5p1RbtwDE1EVzu
+            wjQs1cCRKb5Pz/yUspkQsN3FO4iyWodCy5j3o0CdIJD/1gvq98pf4IG9tA==
+            -----END PUBLIC KEY-----
+verification_annotations: # optional
+  env: prod
+  foo: bar


### PR DESCRIPTION
- Add `--enable-verification`, `--verification-path` flags and their corresponding env vars `KUBEWARDEN_ENABLE_VERIFICATION`, `KUBEWARDEN_VERIFICATION_CONFIG_PATH`.
- If `--enable-verification` or `KUBEWARDEN_ENABLE_VERIFICATION` is set, read the verification yaml file (default `verification.yml`). the policy-server will verify the policy using all the keys provided and all the annotations. Expecting verification and providing no verification keys is regarded an error. Verification annotations are optional. Emit logs with `status=verified-signatures`, `status=verified-local-checksum`.

Examples:
With policies.yml:
```yaml
pod-privileged:
  url: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
```

1. And verification.yml:
```yaml
---
verification_keys:
  key-name-irrelevant: |
            -----BEGIN PUBLIC KEY-----
            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEX0HFTtCfTtPmkx5p1RbtwDE1EVzu
            wjQs1cCRKb5Pz/yUspkQsN3FO4iyWodCy5j3o0CdIJD/1gvq98pf4IG9tA==
            -----END PUBLIC KEY-----
  another-key: |
            -----BEGIN PUBLIC KEY-----
            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEX0HFTtCfTtPmkx5p1RbtwDE1EVzu
            wjQs1cCRKb5Pz/yUspkQsN3FO4iyWodCy5j3o0CdIJD/1gvq98pf4IG9tA==
            -----END PUBLIC KEY-----
```
```console
$ RUST_BACKTRACE=1 KUBEWARDEN_ENABLE_VERIFICATION=1 ./target/release/policy-server
Dec 02 17:59:31.576  INFO policy_server: policies download download_dir="." policies_count=1 status="init"
Dec 02 17:59:32.928  INFO sigstore::crypto: skipping layer, it wasn't signed with the given key
Dec 02 17:59:33.721  INFO sigstore::crypto: skipping layer, it wasn't signed with the given key
Dec 02 17:59:33.721  INFO policy_server: policy download name="pod-privileged" sha256sum="sha256:0d6611ea12cf2904066308dde1c480b5d4f40e19b12f51f101a256b44d6c2dd5" status="verified-signatures"
Dec 02 17:59:34.207  INFO policy_fetcher::verify: Local file checksum verification passed
Dec 02 17:59:34.207  INFO policy_server: policy download name="pod-privileged" sha256sum="sha256:0d6611ea12cf2904066308dde1c480b5d4f40e19b12f51f101a256b44d6c2dd5" status="verified-local-checksum"
Dec 02 17:59:34.207  INFO policy_server: policy download name="pod-privileged" path="./registry/ghcr.io/kubewarden/tests/pod-privileged:v0.1.9" sha256sum="sha256:0d6611ea12cf2904066308dde1c480b5d4f40e19b12f51f101a256b44d6c2dd5" mutating=false
Dec 02 17:59:34.207  INFO policy_server: policies download status="done"

```

2. And verification.yml:
```yaml
---
verification_keys:
  key-name-irrelevant: |
            -----BEGIN PUBLIC KEY-----
            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEX0HFTtCfTtPmkx5p1RbtwDE1EVzu
            wjQs1cCRKb5Pz/yUspkQsN3FO4iyWodCy5j3o0CdIJD/1gvq98pf4IG9tA==
            -----END PUBLIC KEY-----
  another-key: |
            -----BEGIN PUBLIC KEY-----
            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEX0HFTtCfTtPmkx5p1RbtwDE1EVzu
            wjQs1cCRKb5Pz/yUspkQsN3FO4iyWodCy5j3o0CdIJD/1gvq98pf4IG9tA==
            -----END PUBLIC KEY-----
verification_annotations:
  foo: bar # expecting failure as the image is not signed with this annotation
```
```console
vic@viccuad2 130 ~/suse/kw/policy-server (policy-verify $%>)$ RUST_BACKTRACE=1 KUBEWARDEN_ENABLE_VERIFICATION=1 ./target/release/policy-server
Dec 02 18:01:35.802  INFO policy_server: policies download download_dir="." policies_count=1 status="init"
Dec 02 18:01:37.063  INFO sigstore::simple_signing: Annotation not satisfied missing_annotation="foo" layer_annotations={"stable": String("true"), "env": String("prod")}
Dec 02 18:01:37.064  INFO sigstore::crypto: skipping layer, it wasn't signed with the given key
Dec 02 18:01:37.064 ERROR policy_server: The signature object didn't have any layer signed with the given key
```
(note: ERROR will be as descriptive as INFO when policy-fetcher is rebased for sigstore-rs >= 0.2.0)

Fixes: https://github.com/kubewarden/policy-server/issues/98


