### PR TITLE
 Adds mutating settings field.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 HYPERFINE := $(shell command -v hyperfine 2> /dev/null)
+IMG ?= policy-server:latest
 
 .PHONY: build
 build:
@@ -26,3 +27,7 @@ tag:
 	@git-chglog --output CHANGELOG.md
 	@git commit -m 'Update CHANGELOG.md' -- CHANGELOG.md
 	@git tag -f "${TAG}"
+
+.PHONY: docker-build
+docker-build: test ## Build docker image with the manager.
+	docker build -t ${IMG} .


### PR DESCRIPTION
Adds the "mutating" field in the settings. This allows policy server to check if a policy is allowed to mutate a request. If the policy mutate the request, but its "mutating" settings is false, the request is rejected.

Fixes: https://github.com/kubewarden/policy-server/issues/137.