### PR TITLE
feat: Config dependabot to only bump minor, patch vers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
     interval: daily
     time: "13:00"
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major"]  # Security updates are unaffected by this setting


### PR DESCRIPTION
Security updates are unaffected by this setting.

See [1].

[1]: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore