### PR TITLE
Update to latest version of clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "base64",
  "chrono",
  "chrono-tz",
- "clap",
+ "clap 2.34.0",
  "gtmpl",
  "gtmpl_value",
  "itertools",
@@ -493,9 +493,25 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+dependencies = [
+ "atty",
+ "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.14.2",
 ]
 
 [[package]]
@@ -2100,6 +2116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "p256"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,7 +2324,7 @@ version = "0.2.6-rc1"
 dependencies = [
  "anyhow",
  "async-stream",
- "clap",
+ "clap 3.0.10",
  "futures-util",
  "hyper",
  "itertools",
@@ -3119,6 +3144,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.3.0" }
 kubewarden-policy-sdk = "0.3.2"
 lazy_static = "1.4.0"
-clap = "2.33.3"
+clap = { version = "3.0.10", features = [ "cargo", "env" ] }
 futures-util = "0.3.12"
 kube = { version = "0.64.0", default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["v1_22"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,64 +30,72 @@ lazy_static! {
         std::env::var("HOSTNAME").unwrap_or_else(|_| String::from("unknown"));
 }
 
-pub(crate) fn build_cli() -> App<'static, 'static> {
+pub(crate) fn build_cli() -> App<'static> {
     App::new(crate_name!())
         .author(crate_authors!())
         .version(crate_version!())
         .about(crate_description!())
         .arg(
-            Arg::with_name("log-level")
+            Arg::new("log-level")
                 .long("log-level")
+                .takes_value(true)
                 .env("KUBEWARDEN_LOG_LEVEL")
                 .default_value("info")
                 .possible_values(&["trace", "debug", "info", "warn", "error"])
                 .help("Log level"),
         )
         .arg(
-            Arg::with_name("log-fmt")
+            Arg::new("log-fmt")
                 .long("log-fmt")
+                .takes_value(true)
                 .env("KUBEWARDEN_LOG_FMT")
                 .default_value("text")
                 .possible_values(&["text", "json", "otlp"])
                 .help("Log output format"),
         )
         .arg(
-            Arg::with_name("address")
+            Arg::new("address")
                 .long("addr")
+                .takes_value(true)
                 .default_value("0.0.0.0")
                 .env("KUBEWARDEN_BIND_ADDRESS")
                 .help("Bind against ADDRESS"),
         )
         .arg(
-            Arg::with_name("port")
+            Arg::new("port")
                 .long("port")
+                .takes_value(true)
                 .default_value("3000")
                 .env("KUBEWARDEN_PORT")
                 .help("Listen on PORT"),
         )
         .arg(
-            Arg::with_name("workers")
+            Arg::new("workers")
                 .long("workers")
+                .takes_value(true)
                 .env("KUBEWARDEN_WORKERS")
                 .help("Number of workers thread to create"),
         )
         .arg(
-            Arg::with_name("cert-file")
+            Arg::new("cert-file")
                 .long("cert-file")
+                .takes_value(true)
                 .default_value("")
                 .env("KUBEWARDEN_CERT_FILE")
                 .help("Path to an X.509 certificate file for HTTPS"),
         )
         .arg(
-            Arg::with_name("key-file")
+            Arg::new("key-file")
                 .long("key-file")
+                .takes_value(true)
                 .default_value("")
                 .env("KUBEWARDEN_KEY_FILE")
                 .help("Path to an X.509 private key file for HTTPS"),
         )
         .arg(
-            Arg::with_name("policies")
+            Arg::new("policies")
                 .long("policies")
+                .takes_value(true)
                 .env("KUBEWARDEN_POLICIES")
                 .default_value("policies.yml")
                 .help(
@@ -96,44 +104,49 @@ pub(crate) fn build_cli() -> App<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("policies-download-dir")
+            Arg::new("policies-download-dir")
                 .long("policies-download-dir")
+                .takes_value(true)
                 .default_value(".")
                 .env("KUBEWARDEN_POLICIES_DOWNLOAD_DIR")
                 .help("Download path for the policies"),
         )
         .arg(
-            Arg::with_name("sources-path")
+            Arg::new("sources-path")
                 .takes_value(true)
                 .long("sources-path")
+                .takes_value(true)
                 .env("KUBEWARDEN_SOURCES_PATH")
                 .help("YAML file holding source information (https, registry insecure hosts, custom CA's...)"),
         )
         .arg(
-            Arg::with_name("verification-path")
+            Arg::new("verification-path")
                 .env("KUBEWARDEN_VERIFICATION_CONFIG_PATH")
                 .long("verification-path")
+                .takes_value(true)
                 .help("YAML file holding verification information (URIs, keys, annotations...)"),
         )
         .arg(
-            Arg::with_name("docker-config-json-path")
+            Arg::new("docker-config-json-path")
                 .env("KUBEWARDEN_DOCKER_CONFIG_JSON_PATH")
                 .long("docker-config-json-path")
                 .takes_value(true)
                 .help("Path to a Docker config.json-like path. Can be used to indicate registry authentication details"),
         )
         .arg(
-            Arg::with_name("enable-metrics")
+            Arg::new("enable-metrics")
                 .long("enable-metrics")
-                .required(false)
                 .takes_value(false)
+                .env("KUBEWARDEN_ENABLE_METRICS")
+                .required(false)
                 .help("Enable metrics [env: KUBEWARDEN_ENABLE_METRICS=]"),
         )
         .arg(
-            Arg::with_name("enable-verification")
+            Arg::new("enable-verification")
                 .long("enable-verification")
-                .required(false)
                 .takes_value(false)
+                .env("KUBEWARDEN_ENABLE_VERIFICATION")
+                .required(false)
                 .help("Enable Sigstore verification [env: KUBEWARDEN_ENABLE_VERIFICATION=]"),
         )
         .long_version(VERSION_AND_BUILTINS.as_str())

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,30 +44,8 @@ fn main() -> Result<()> {
             .expect("error parsing the number of workers")
     });
 
-    // As of clap version 2, we have to do this check in separate
-    // steps.
-    //
-    // `--enable-metrics` does not take a value. However, using
-    // `env` from clap to link the `KUBEWARDEN_ENABLE_METRICS`
-    // envvar to this flag forcefully sets `takes_value` on the
-    // flag, making the usage of `--enable-metrics` argument weird
-    // (this should not take a value).
-    //
-    // The answer is therefore, to just set up the
-    // `--enable-metrics` flag in clap, and check manually whether
-    // the environment variable is set.
-    //
-    // The same is true for `--verify-policies` flag, and
-    // KUBEWARDEN_ENABLE_VERIFICATION env var.
-    //
-    // Check https://github.com/clap-rs/clap/issues/1476 for
-    // further details.
-    let metrics_enabled = matches.is_present("enable-metrics")
-        || std::env::var_os("KUBEWARDEN_ENABLE_METRICS").is_some();
-    let verify_enabled = matches.is_present("enable-verification")
-        || std::env::var_os("KUBEWARDEN_ENABLE_VERIFICATION").is_some()
-        || matches.is_present("verification-path");
-
+    let metrics_enabled = matches.is_present("enable-metrics");
+    let verify_enabled = matches.is_present("enable-verification");
     let verification_settings: Option<VerificationSettings> = if verify_enabled {
         Some(cli::verification_settings(&matches)?)
     } else {


### PR DESCRIPTION
Adapt the code to address the major changes brought by the major update of clap.

Also, dropped the custom code we had to write to handle `--enable-XXX` flags via environment variables. Clap v2 didn't support them, but this got addressed with v3.

Now it's possible to enable verification and monitoring via `KUBEWARDEN_ENABLE_METRICS=1` and `KUBEWARDEN_ENABLE_VERIFICATION=1` without our custom code.

This supersedes https://github.com/kubewarden/policy-server/pull/148

