### PR TITLE
fix: Enable verification if `--verification-path` is passed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,8 @@ fn main() -> Result<()> {
     });
 
     let metrics_enabled = matches.is_present("enable-metrics");
-    let verify_enabled = matches.is_present("enable-verification");
+    let verify_enabled =
+        matches.is_present("enable-verification") || matches.is_present("verification-path");
     let verification_settings: Option<VerificationSettings> = if verify_enabled {
         Some(cli::verification_settings(&matches)?)
     } else {


### PR DESCRIPTION
This was dropped in the clap bump.

With this, the correct behaviour is back:
- use verification if `--enable-verification` or `KUBEWARDEN_ENABLE_VERIFICATION=1` is present.
-  use verification if `--verification-path=foo` is present (expected by controller).