### PR TITLE
Monitor mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 [[package]]
 name = "burrego"
 version = "0.1.2"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.12#0419eb5cc47d242818377d07e1389bc7ac69b1b4"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.13#11d7d7aa5b66620b80e51c1077a8fc4479991b6e"
 dependencies = [
  "anyhow",
  "base64",
@@ -2303,8 +2303,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.2.12"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.12#0419eb5cc47d242818377d07e1389bc7ac69b1b4"
+version = "0.2.13"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.13#11d7d7aa5b66620b80e51c1077a8fc4479991b6e"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 anyhow = "1.0"
 async-stream = "0.3.2"
 itertools = "0.10.3"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.12" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.13" }
 policy-fetcher = { git = "https://github.com/kubewarden/policy-fetcher", tag = "v0.4.3" }
 kubewarden-policy-sdk = "0.3.2"
 lazy_static = "1.4.0"

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -24,6 +24,7 @@ pub(crate) fn init_meter() -> metrics::Result<PushController> {
 #[derive(Clone)]
 pub struct PolicyEvaluation {
     pub(crate) policy_name: String,
+    pub(crate) policy_mode: String,
     pub(crate) resource_name: String,
     pub(crate) resource_kind: String,
     pub(crate) resource_namespace: Option<String>,
@@ -38,6 +39,7 @@ impl Into<Vec<KeyValue>> for &PolicyEvaluation {
     fn into(self) -> Vec<KeyValue> {
         let mut baggage = vec![
             KeyValue::new("policy_name", self.policy_name.clone()),
+            KeyValue::new("policy_mode", self.policy_mode.clone()),
             KeyValue::new("resource_name", self.resource_name.clone()),
             KeyValue::new("resource_kind", self.resource_kind.clone()),
             KeyValue::new(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,8 +8,24 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 #[derive(Deserialize, Debug, Clone)]
+pub enum PolicyMode {
+    #[serde(rename = "monitor")]
+    Monitor,
+    #[serde(rename = "protect")]
+    Protect,
+}
+
+impl Default for PolicyMode {
+    fn default() -> PolicyMode {
+        PolicyMode::Protect
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct Policy {
     pub url: String,
+    #[serde(default)]
+    pub mode: PolicyMode,
     #[serde(rename = "allowedToMutate")]
     pub allowed_to_mutate: Option<bool>,
     #[serde(skip)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,11 +21,20 @@ impl Default for PolicyMode {
     }
 }
 
+impl From<PolicyMode> for String {
+    fn from(policy_mode: PolicyMode) -> String {
+        match policy_mode {
+            PolicyMode::Monitor => String::from("monitor"),
+            PolicyMode::Protect => String::from("protect"),
+        }
+    }
+}
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct Policy {
     pub url: String,
-    #[serde(default)]
-    pub mode: PolicyMode,
+    #[serde(default, rename = "policyMode")]
+    pub policy_mode: PolicyMode,
     #[serde(rename = "allowedToMutate")]
     pub allowed_to_mutate: Option<bool>,
     #[serde(skip)]


### PR DESCRIPTION
Fixes: https://github.com/kubewarden/policy-server/issues/190

feat: implement policy modes

Policies can be configured to either be in `monitor` or `protect`
modes. When a policy is in `protect` mode, it will accept, reject or
mutate requests. When a policy is in `monitor` mode, it will always
accept all requests, but will log what would have been its decision if
it had been in `protect` mode.

This is helpful if you want to check how a policy would behave before
it starts to take decisions on a Kubernetes cluster.