### PR TITLE
Update kube crate to version v0.71.0 and policy-evaluator to v0.2.18.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 [[package]]
 name = "burrego"
 version = "0.1.2"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.16#e535c7ffcf4d66d650769f582f9206d58bb263aa"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.18#0a820a5abe08907f4b6476ee1aa74c7ffd9d3982"
 dependencies = [
  "anyhow",
  "base64",
@@ -1579,9 +1579,9 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kube"
-version = "0.68.0"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41f782ddd187a0d8965607679bbd741052106b75330696ce7d7712b13194d88"
+checksum = "342744dfeb81fe186b84f485b33f12c6a15d3396987d933b06a566a3db52ca38"
 dependencies = [
  "k8s-openapi 0.14.0",
  "kube-client",
@@ -1590,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.68.0"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cced1a3e738c2a4bccb52d33066632369c668f366a71c9c58139d9360e1a341d"
+checksum = "3f69a504997799340408635d6e351afb8aab2c34ca3165e162f41b3b34a69a79"
 dependencies = [
  "base64",
  "bytes",
@@ -1611,14 +1611,14 @@ dependencies = [
  "pem",
  "pin-project",
  "rustls",
- "rustls-pemfile 0.2.1",
+ "rustls-pemfile 0.3.0",
  "secrecy",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.1",
  "tower",
  "tower-http",
  "tracing",
@@ -1626,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.68.0"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878656f5e349ef08b0a48d2b1841f1e68c4cf1ef42524feadad2f9a109dd888"
+checksum = "a4a247487699941baaf93438d65b12d4e32450bea849d619d19ed394e8a4a645"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2407,8 +2407,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.2.16"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.16#e535c7ffcf4d66d650769f582f9206d58bb263aa"
+version = "0.2.18"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.18#0a820a5abe08907f4b6476ee1aa74c7ffd9d3982"
 dependencies = [
  "anyhow",
  "base64",
@@ -2427,14 +2427,14 @@ dependencies = [
  "tracing-futures",
  "validator",
  "wapc",
- "wasmparser 0.82.0",
+ "wasmparser 0.84.0",
  "wasmtime-provider",
 ]
 
 [[package]]
 name = "policy-fetcher"
-version = "0.6.0"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.6.0#b53e7f9ced222a3ede6c8368645f5d57859d4921"
+version = "0.6.1"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.6.1#75dfde5f6ecc619147646d55d48ab9ce84e1b5b8"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2445,6 +2445,7 @@ dependencies = [
  "lazy_static",
  "oci-distribution",
  "path-slash",
+ "rayon",
  "regex",
  "reqwest",
  "rustls",
@@ -4055,9 +4056,12 @@ checksum = "98930446519f63d00a836efdc22f67766ceae8dbcc1571379f2bcabc6b2b9abc"
 
 [[package]]
 name = "wasmparser"
-version = "0.82.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0559cc0f1779240d6f894933498877ea94f693d84f3ee39c9a9932c6c312bd70"
+checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "wasmtime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2018"
 anyhow = "1.0"
 async-stream = "0.3.3"
 itertools = "0.10.3"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.16" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.18" }
 kubewarden-policy-sdk = "0.3.2"
 lazy_static = "1.4.0"
 clap = { version = "3.0.15", features = [ "cargo", "env" ] }
 futures-util = "0.3.21"
-kube = { version = "0.68.0", default-features = false, features = ["client", "rustls-tls"] }
+kube = { version = "0.71.0", default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22"] }
 hyper = { version = "0.14", features = ["full"] }
 num_cpus = "1.13.1"


### PR DESCRIPTION
The kube crate version v0.70.0 added support for ECDSA algorithm. Which is necessary to fix a certificate issue when trying to run PolicyServer in K3D and Minikube cluster. This commit updates the crate version to fix the issue.

Fix #136 
Depends on https://github.com/kubewarden/policy-evaluator/pull/114

## Test

```shell
# start a k3d/minikube cluster
# workaroud the IP issue as described at https://github.com/kubewarden/policy-server/issues/136#issuecomment-1013092030
# in the policy server repository run:
cargo run --release -- --policies policies.yml --workers 2
```

