### PR TITLE
gh test action: authenticate against GHCR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,18 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
+      # log into ghcr using the GITHUB_TOKEN, this is needed
+      # because one of the tests below downloads a small policy from
+      # ghcr. Being authenticated should eliminate the chances of this GH
+      # action being blocked/rate limited by ghcr
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2466,6 +2466,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "clap",
+ "directories",
  "futures-util",
  "hyper",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tracing-futures = "0.2"
 tracing-opentelemetry = "0.17.2"
 
 [dev-dependencies]
+directories = "4.0.1"
 tempfile = "3.3.0"
 
 [patch.crates-io]


### PR DESCRIPTION
GHCR must have some abuse system in place that blocks lots of connections done in an anonymous way. This seems to be causing our GH action testing policy-server to fail.

This commit ensures we perform authenticate operations against GHCR. The GITHUB_TOKEN is used to authenticate against ghcr.io

The testing done on my fork seems to prove this change helps. Unfortunately we will not know for sure until we merge this fix here.