### PR TITLE
feat: Allow policy authors to write policies that perform image verification using sigstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 [[package]]
 name = "burrego"
 version = "0.1.2"
-source = "git+https://github.com/raulcabello/policy-evaluator?branch=sigstore_container_verification3#14d3308d0015de4add290f41afc26b5d81d53884"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.3.0#6bf71a56cf8db521c0fecc61b6fcde1ab99d5e1c"
 dependencies = [
  "anyhow",
  "base64",
@@ -1730,8 +1730,8 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.3.2"
-source = "git+https://github.com/raulcabello/policy-sdk-rust?branch=sigstore_container_verification#107827f8d8259848534f25eadba1130143c7fbde"
+version = "0.4.0"
+source = "git+https://github.com/kubewarden/policy-sdk-rust?tag=v0.4.0#5a000314ebcc6398f759968bf2822103f08c6dc5"
 dependencies = [
  "anyhow",
  "k8s-openapi 0.14.0",
@@ -2593,8 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.2.18"
-source = "git+https://github.com/raulcabello/policy-evaluator?branch=sigstore_container_verification3#14d3308d0015de4add290f41afc26b5d81d53884"
+version = "0.3.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.3.0#6bf71a56cf8db521c0fecc61b6fcde1ab99d5e1c"
 dependencies = [
  "anyhow",
  "base64",
@@ -2603,7 +2603,7 @@ dependencies = [
  "hyper",
  "json-patch",
  "kube",
- "kubewarden-policy-sdk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kubewarden-policy-sdk 0.3.2",
  "lazy_static",
  "policy-fetcher",
  "serde",
@@ -2619,8 +2619,8 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.6.1"
-source = "git+https://github.com/kubewarden/policy-fetcher?branch=sigstore_container_verification#3ead76d6c18f91e3e1160a1fca7781693dbdc145"
+version = "0.7.0"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.7.0#97178fca6c93316909f367570d9267f1a92c88e6"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2628,7 +2628,7 @@ dependencies = [
  "async-trait",
  "base64",
  "directories",
- "kubewarden-policy-sdk 0.3.2 (git+https://github.com/raulcabello/policy-sdk-rust?branch=sigstore_container_verification)",
+ "kubewarden-policy-sdk 0.4.0",
  "lazy_static",
  "oci-distribution",
  "path-slash",
@@ -2658,7 +2658,7 @@ dependencies = [
  "itertools 0.10.3",
  "k8s-openapi 0.14.0",
  "kube",
- "kubewarden-policy-sdk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kubewarden-policy-sdk 0.3.2",
  "lazy_static",
  "num_cpus",
  "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_once"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
+
+[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +221,15 @@ dependencies = [
  "hermit-abi",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -314,7 +329,7 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 [[package]]
 name = "burrego"
 version = "0.1.2"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.18#0a820a5abe08907f4b6476ee1aa74c7ffd9d3982"
+source = "git+https://github.com/raulcabello/policy-evaluator?branch=sigstore_container_verification3#14d3308d0015de4add290f41afc26b5d81d53884"
 dependencies = [
  "anyhow",
  "base64",
@@ -323,7 +338,7 @@ dependencies = [
  "clap",
  "gtmpl",
  "gtmpl_value",
- "itertools",
+ "itertools 0.10.3",
  "json-patch",
  "lazy_static",
  "regex",
@@ -364,11 +379,29 @@ dependencies = [
  "async-mutex",
  "async-rwlock",
  "async-trait",
- "cached_proc_macro",
+ "cached_proc_macro 0.9.0",
  "cached_proc_macro_types",
  "futures",
- "hashbrown",
+ "hashbrown 0.11.2",
  "once_cell",
+]
+
+[[package]]
+name = "cached"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aadf76ddea74bab35ebeb8f1eb115b9bc04eaee42d8acc0d5f477dee6b176c9a"
+dependencies = [
+ "async-trait",
+ "async_once",
+ "cached_proc_macro 0.12.0",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown 0.12.0",
+ "lazy_static",
+ "once_cell",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -376,6 +409,18 @@ name = "cached_proc_macro"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "725f434d6da2814b989bd905c62ca28a9383feff7440210dc279665fbbbc9511"
+dependencies = [
+ "cached_proc_macro_types",
+ "darling",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce0f37f9b77c6b93cdf3f060c89adca303d2ab052cacb3c3d1ab543e8cecd2f"
 dependencies = [
  "cached_proc_macro_types",
  "darling",
@@ -662,7 +707,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools",
+ "itertools 0.10.3",
  "log",
  "smallvec",
  "wasmparser 0.81.0",
@@ -705,7 +750,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -1165,8 +1210,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1252,6 +1299,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
 
 [[package]]
 name = "heck"
@@ -1440,8 +1493,8 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
- "autocfg",
- "hashbrown",
+ "autocfg 1.1.0",
+ "hashbrown 0.11.2",
  "serde",
 ]
 
@@ -1478,6 +1531,15 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1561,7 +1623,7 @@ dependencies = [
  "http",
  "percent-encoding 2.1.0",
  "serde",
- "serde-value",
+ "serde-value 0.7.0",
  "serde_json",
  "url 2.2.2",
 ]
@@ -1576,7 +1638,7 @@ dependencies = [
  "bytes",
  "chrono",
  "serde",
- "serde-value",
+ "serde-value 0.7.0",
  "serde_json",
 ]
 
@@ -1667,6 +1729,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubewarden-policy-sdk"
+version = "0.3.2"
+source = "git+https://github.com/raulcabello/policy-sdk-rust?branch=sigstore_container_verification#107827f8d8259848534f25eadba1130143c7fbde"
+dependencies = [
+ "anyhow",
+ "k8s-openapi 0.14.0",
+ "num",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "slog",
+ "url 2.2.2",
+ "wapc-guest",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,7 +1812,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -1797,7 +1877,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1895,9 +1975,27 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4547ee5541c18742396ae2c895d0717d0f886d8823b8399cdaf7b07d63ad0480"
+dependencies = [
+ "autocfg 0.1.8",
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -1944,7 +2042,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -1954,7 +2052,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -1965,7 +2063,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1977,7 +2075,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "libm",
 ]
 
@@ -1989,6 +2087,26 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "oauth2"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e47cfc4c0a1a519d9a025ebfbac3a2439d1b5cdf397d72dcb79b11d9920dab"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom",
+ "http",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.9.9",
+ "thiserror",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -2075,6 +2193,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9213e7b66aa06a7722828ee2980c1adff22a3922b582baaa1e62e30ca2a6c018"
+dependencies = [
+ "pathdiff",
+ "winapi",
+]
+
+[[package]]
+name = "openidconnect"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691c1ba89b0a112f3062b946ef160711c3aea33e1476b6877a904f2f83856781"
+dependencies = [
+ "base64",
+ "chrono",
+ "http",
+ "itertools 0.9.0",
+ "log",
+ "num-bigint",
+ "oauth2",
+ "rand",
+ "ring",
+ "serde",
+ "serde-value 0.6.0",
+ "serde_derive",
+ "serde_json",
+ "serde_path_to_error",
+ "thiserror",
+ "untrusted",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2273,15 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2231,6 +2393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cacbb3c4ff353b534a67fb8d7524d00229da4cb1dc8c79f4db96e375ab5b619"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "pem"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,12 +2480,13 @@ dependencies = [
 [[package]]
 name = "picky"
 version = "7.0.0-rc.2"
-source = "git+https://github.com/Devolutions/picky-rs.git?tag=picky-7.0.0-rc.2#912af2ea93051e53aadf97a1dc8bb5e43dee51ee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3b395af6b8f9c4d159644dcbecb750b671f7161de1f76c2931957127dd6998"
 dependencies = [
  "base64",
  "digest 0.10.3",
  "md-5",
- "num-bigint-dig",
+ "num-bigint-dig 0.8.1",
  "oid",
  "picky-asn1",
  "picky-asn1-der",
@@ -2335,7 +2504,8 @@ dependencies = [
 [[package]]
 name = "picky-asn1"
 version = "0.5.0"
-source = "git+https://github.com/Devolutions/picky-rs.git?tag=picky-7.0.0-rc.2#912af2ea93051e53aadf97a1dc8bb5e43dee51ee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1088a7f82ee21e534da0f62b074b559d2a0717b0d5104ba7a47c1f5bc6c83f69"
 dependencies = [
  "oid",
  "serde",
@@ -2345,7 +2515,8 @@ dependencies = [
 [[package]]
 name = "picky-asn1-der"
 version = "0.3.0"
-source = "git+https://github.com/Devolutions/picky-rs.git?tag=picky-7.0.0-rc.2#912af2ea93051e53aadf97a1dc8bb5e43dee51ee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9e1454c26d52ef1951149e611ca2851673fea960269060887acc6793e3e683"
 dependencies = [
  "picky-asn1",
  "serde",
@@ -2355,10 +2526,11 @@ dependencies = [
 [[package]]
 name = "picky-asn1-x509"
 version = "0.7.0"
-source = "git+https://github.com/Devolutions/picky-rs.git?tag=picky-7.0.0-rc.2#912af2ea93051e53aadf97a1dc8bb5e43dee51ee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73a6e765347b2beb0267a15aefa29136ddd3b7ac0a4304c7db4782a51f405492"
 dependencies = [
  "base64",
- "num-bigint-dig",
+ "num-bigint-dig 0.7.0",
  "oid",
  "picky-asn1",
  "picky-asn1-der",
@@ -2422,16 +2594,16 @@ dependencies = [
 [[package]]
 name = "policy-evaluator"
 version = "0.2.18"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.2.18#0a820a5abe08907f4b6476ee1aa74c7ffd9d3982"
+source = "git+https://github.com/raulcabello/policy-evaluator?branch=sigstore_container_verification3#14d3308d0015de4add290f41afc26b5d81d53884"
 dependencies = [
  "anyhow",
  "base64",
  "burrego",
- "cached",
+ "cached 0.30.0",
  "hyper",
  "json-patch",
  "kube",
- "kubewarden-policy-sdk",
+ "kubewarden-policy-sdk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "policy-fetcher",
  "serde",
@@ -2448,7 +2620,7 @@ dependencies = [
 [[package]]
 name = "policy-fetcher"
 version = "0.6.1"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.6.1#75dfde5f6ecc619147646d55d48ab9ce84e1b5b8"
+source = "git+https://github.com/kubewarden/policy-fetcher?branch=sigstore_container_verification#3ead76d6c18f91e3e1160a1fca7781693dbdc145"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2456,6 +2628,7 @@ dependencies = [
  "async-trait",
  "base64",
  "directories",
+ "kubewarden-policy-sdk 0.3.2 (git+https://github.com/raulcabello/policy-sdk-rust?branch=sigstore_container_verification)",
  "lazy_static",
  "oci-distribution",
  "path-slash",
@@ -2482,10 +2655,10 @@ dependencies = [
  "clap",
  "futures-util",
  "hyper",
- "itertools",
+ "itertools 0.10.3",
  "k8s-openapi 0.14.0",
  "kube",
- "kubewarden-policy-sdk",
+ "kubewarden-policy-sdk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "num_cpus",
  "opentelemetry",
@@ -2575,7 +2748,7 @@ checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.10.3",
  "lazy_static",
  "log",
  "multimap",
@@ -2594,7 +2767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -2664,7 +2837,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -2822,7 +2995,7 @@ checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
 dependencies = [
  "byteorder",
  "digest 0.10.3",
- "num-bigint-dig",
+ "num-bigint-dig 0.8.1",
  "num-integer",
  "num-iter",
  "num-traits",
@@ -3018,11 +3191,21 @@ dependencies = [
 
 [[package]]
 name = "serde-value"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
+dependencies = [
+ "ordered-float 1.1.1",
+ "serde",
+]
+
+[[package]]
+name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.0",
  "serde",
 ]
 
@@ -3055,6 +3238,15 @@ dependencies = [
  "indexmap",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7868ad3b8196a8a0aea99a8220b124278ee5320a55e4fde97794b6f85b1a377"
+dependencies = [
  "serde",
 ]
 
@@ -3166,13 +3358,16 @@ dependencies = [
 [[package]]
 name = "sigstore"
 version = "0.2.0"
-source = "git+https://github.com/sigstore/sigstore-rs?rev=3954129ff0fc91beb8b8a6568ecb09e8c2d19392#3954129ff0fc91beb8b8a6568ecb09e8c2d19392"
+source = "git+https://github.com/sigstore/sigstore-rs?rev=cb3606a9d3d05a5e318bb3837f48c560c01cc2ff#cb3606a9d3d05a5e318bb3837f48c560c01cc2ff"
 dependencies = [
  "async-trait",
  "base64",
+ "cached 0.34.0",
  "lazy_static",
  "oci-distribution",
  "olpc-cjson",
+ "open",
+ "openidconnect",
  "pem",
  "picky",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 anyhow = "1.0"
 async-stream = "0.3.3"
 itertools = "0.10.3"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.2.18" }
+policy-evaluator = { git = "https://github.com/raulcabello/policy-evaluator", branch = "sigstore_container_verification3" }
 kubewarden-policy-sdk = "0.3.2"
 lazy_static = "1.4.0"
 clap = { version = "3.0.15", features = [ "cargo", "env" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 anyhow = "1.0"
 async-stream = "0.3.3"
 itertools = "0.10.3"
-policy-evaluator = { git = "https://github.com/raulcabello/policy-evaluator", branch = "sigstore_container_verification3" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.3.0" }
 kubewarden-policy-sdk = "0.3.2"
 lazy_static = "1.4.0"
 clap = { version = "3.0.15", features = [ "cargo", "env" ] }


### PR DESCRIPTION
## Description

pass fulcio_and_rekor_data to the Callback handler builder, since it is now needed for running policies that uses sigstore verification

Fix https://github.com/kubewarden/policy-server/issues/99