### PR TITLE
Add option to always accept admission reviews on a given namespace

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -160,6 +160,14 @@ pub(crate) fn build_cli() -> Command<'static> {
                 .required(false)
                 .help("Enable Sigstore verification [env: KUBEWARDEN_ENABLE_VERIFICATION=]"),
         )
+        .arg(
+            Arg::new("always-accept-admission-reviews-on-namespace")
+                .long("always-accept-admission-reviews-on-namespace")
+                .takes_value(true)
+                .env("ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE")
+                .required(false)
+                .help("Always accept AdmissionReviews that target the given namespace [env: ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE]"),
+        )
         .long_version(VERSION_AND_BUILTINS.as_str())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,9 +164,9 @@ pub(crate) fn build_cli() -> Command<'static> {
             Arg::new("always-accept-admission-reviews-on-namespace")
                 .long("always-accept-admission-reviews-on-namespace")
                 .takes_value(true)
-                .env("ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE")
+                .env("KUBEWARDEN_ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE")
                 .required(false)
-                .help("Always accept AdmissionReviews that target the given namespace [env: ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE]"),
+                .help("Always accept AdmissionReviews that target the given namespace [env: KUBEWARDEN_ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE]"),
         )
         .long_version(VERSION_AND_BUILTINS.as_str())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,9 @@ fn main() -> Result<()> {
         v.parse::<usize>()
             .expect("error parsing the number of workers")
     });
+    let always_accept_admission_reviews_on_namespace = matches
+        .value_of("always-accept-admission-reviews-on-namespace")
+        .map(str::to_string);
 
     let metrics_enabled = matches.is_present("enable-metrics");
     let verification_config = cli::verification_config(&matches).unwrap_or_else(|e| {
@@ -118,6 +121,7 @@ fn main() -> Result<()> {
             worker_pool_bootstrap_req_rx,
             api_rx,
             callback_sender_channel,
+            always_accept_admission_reviews_on_namespace,
         );
         worker_pool.run();
     });


### PR DESCRIPTION
Fixes: https://github.com/kubewarden/policy-server/issues/246

Add an `--always-accept-admission-reviews-on-namespace` option that
will always allow requests on the given namespace. Mutations are not
altered, and are allowed to happen in this namespace. However, all
evaluations of all policies will be evaluated to `allowed: true` if
provided.

This argument is optional, and by default, if not provided, the
behavior of the `policy-server` is unchanged.

This argument can also be provided as an environment variable named
`ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE`.

This argument only accepts one namespace, either provided as a CLI
argument or as an environment variable. Providing a list of namespaces
is not supported.