### PR TITLE
Sign policy-server image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -66,6 +66,9 @@ jobs:
   build-container-image:
     name: Build container image
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      id-token: write
     needs:
      - build-x86_64
      - build-aarch64
@@ -110,3 +113,19 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/policy-server:${{ env.TAG_NAME }}
+      - uses: sigstore/cosign-installer@main
+      - name: Sign the images for releases
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          cosign sign \
+            ghcr.io/${{ github.repository_owner }}/policy-server:${{ env.TAG_NAME }}
+        env:
+          COSIGN_EXPERIMENTAL: 1
+      - name: Sign latest image
+        if: ${{ startsWith(github.ref, 'refs/heads/') }}
+        run: |
+          cosign sign \
+            ghcr.io/${{ github.repository_owner }}/policy-server:latest
+        env:
+          COSIGN_EXPERIMENTAL: 1
+

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -93,6 +93,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push development container image
         if: ${{ startsWith(github.ref, 'refs/heads/') }}
+        id: build-latest
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -106,6 +107,7 @@ jobs:
           echo TAG_NAME=$(echo $GITHUB_REF | sed -e "s|refs/tags/||") >> $GITHUB_ENV
       - name: Build and push tagged container image
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        id: build-tag
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -118,14 +120,14 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           cosign sign \
-            ghcr.io/${{ github.repository_owner }}/policy-server:${{ env.TAG_NAME }}
+            ghcr.io/${{ github.repository_owner }}/policy-server@${{ steps.build-tag.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: 1
       - name: Sign latest image
         if: ${{ startsWith(github.ref, 'refs/heads/') }}
         run: |
           cosign sign \
-            ghcr.io/${{ github.repository_owner }}/policy-server:latest
+            ghcr.io/${{ github.repository_owner }}/policy-server@${{ steps.build-latest.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: 1
 


### PR DESCRIPTION
Use cosign keyless to sign the policy-server image

Tested in my [fork](https://github.com/raulcabello/policy-server/runs/6503089885?check_suite_focus=true) 

```
COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/raulcabello/policy-server:latest | jq
```

output:

```
...
      "Issuer": "https://token.actions.githubusercontent.com",
      "Subject": "https://github.com/raulcabello/policy-server/.github/workflows/container-image.yml@refs/heads/main"
...
```

Fix #255 
