### PR TITLE
cleanup http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "asn1-rs"
@@ -151,25 +151,6 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
 dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-rwlock"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261803dcc39ba9e72760ba6e16d0199b1eef9fc44e81bffabbebb9f5aea3906c"
-dependencies = [
- "async-mutex",
  "event-listener",
 ]
 
@@ -350,6 +331,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,13 +349,12 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 [[package]]
 name = "burrego"
 version = "0.1.3"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.3.7#fd60b4e9c53c3f3298e765ca7e3e09592af61c2e"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.0#fb9ec06c63d59b407973920666b336e337f3997b"
 dependencies = [
  "anyhow",
  "base64",
  "chrono",
  "chrono-tz",
- "clap",
  "gtmpl",
  "gtmpl_value",
  "itertools",
@@ -401,29 +391,13 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cached"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4dfac631a8e77b2f327f7852bb6172771f5279c4512efe79fad6067b37be3d"
-dependencies = [
- "async-mutex",
- "async-rwlock",
- "async-trait",
- "cached_proc_macro 0.9.0",
- "cached_proc_macro_types",
- "futures",
- "hashbrown 0.11.2",
- "once_cell",
-]
-
-[[package]]
-name = "cached"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f5cd208ba696f870238022d81ca1d80ed9d696fd62341c747f2d8f6ecdd9fe"
 dependencies = [
  "async-trait",
  "async_once",
- "cached_proc_macro 0.12.0",
+ "cached_proc_macro",
  "cached_proc_macro_types",
  "futures",
  "hashbrown 0.12.1",
@@ -431,18 +405,6 @@ dependencies = [
  "once_cell",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725f434d6da2814b989bd905c62ca28a9383feff7440210dc279665fbbbc9511"
-dependencies = [
- "cached_proc_macro_types",
- "darling",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -582,15 +544,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -598,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1349,6 +1311,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
+name = "headers"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha-1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,10 +1463,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.20.6",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -1725,7 +1712,7 @@ dependencies = [
  "kube-core",
  "pem",
  "pin-project",
- "rustls",
+ "rustls 0.20.6",
  "rustls-pemfile 1.0.0",
  "secrecy",
  "serde",
@@ -1757,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391ab0fe021e36e6cd59f3ebd5b4ab1889f587d602f840d933c0df1ca3f287b6"
+checksum = "5df1e1d27c3191d89e483ddb7010d4aba1e159ba36307591ff8e4c0018ce1452"
 dependencies = [
  "anyhow",
  "k8s-openapi",
@@ -1909,6 +1896,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase 2.6.0",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,6 +1943,24 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multipart"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log",
+ "mime",
+ "mime_guess",
+ "quick-error",
+ "rand",
+ "safemem",
+ "tempfile",
+ "twoway",
+]
 
 [[package]]
 name = "nom"
@@ -2578,13 +2593,13 @@ dependencies = [
 
 [[package]]
 name = "policy-evaluator"
-version = "0.3.7"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.3.7#fd60b4e9c53c3f3298e765ca7e3e09592af61c2e"
+version = "0.4.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.4.0#fb9ec06c63d59b407973920666b336e337f3997b"
 dependencies = [
  "anyhow",
  "base64",
  "burrego",
- "cached 0.30.0",
+ "cached",
  "dns-lookup",
  "hyper",
  "json-patch",
@@ -2600,7 +2615,7 @@ dependencies = [
  "tracing-futures",
  "validator",
  "wapc",
- "wasmparser 0.85.0",
+ "wasmparser 0.86.0",
  "wasmtime",
  "wasmtime-provider",
 ]
@@ -2622,7 +2637,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "rustls",
+ "rustls 0.20.6",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2635,13 +2650,10 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "0.3.2"
+version = "1.0.0-rc2"
 dependencies = [
  "anyhow",
- "async-stream",
  "clap",
- "futures-util",
- "hyper",
  "itertools",
  "k8s-openapi",
  "lazy_static",
@@ -2649,18 +2661,16 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "policy-evaluator",
- "rustls",
- "rustls-pemfile 1.0.0",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "tokio",
- "tokio-rustls",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "warp",
 ]
 
 [[package]]
@@ -2776,6 +2786,12 @@ checksum = "871372391786ccec00d3c5d3d6608905b3d4db263639cfe075d3b60a736d115a"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2941,13 +2957,13 @@ dependencies = [
  "mime",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.6",
  "rustls-pemfile 0.3.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util 0.6.10",
  "url 2.2.2",
  "wasm-bindgen",
@@ -3031,14 +3047,27 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3078,6 +3107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,10 +3132,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sct"
@@ -3323,7 +3374,7 @@ source = "git+https://github.com/sigstore/sigstore-rs?rev=v0.3.1#eb418d41b6188bb
 dependencies = [
  "async-trait",
  "base64",
- "cached 0.34.1",
+ "cached",
  "lazy_static",
  "oci-distribution",
  "olpc-cjson",
@@ -3624,13 +3675,24 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.6",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3919,6 +3981,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4139,6 +4210,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "warp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multipart",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4274,9 +4375,9 @@ checksum = "0559cc0f1779240d6f894933498877ea94f693d84f3ee39c9a9932c6c312bd70"
 
 [[package]]
 name = "wasmparser"
-version = "0.85.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570460c58b21e9150d2df0eaaedbb7816c34bcec009ae0dcc976e40ba81463e7"
+checksum = "4bcbfe95447da2aa7ff171857fc8427513eb57c75a729bb190e974dc695e8f5c"
 dependencies = [
  "indexmap",
 ]
@@ -4523,6 +4624,16 @@ dependencies = [
 
 [[package]]
 name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -4537,7 +4648,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,24 +10,19 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-async-stream = "0.3.3"
 itertools = "0.10.3"
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.3.7" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.4.0" }
 lazy_static = "1.4.0"
 clap = { version = "3.0.15", features = [ "cargo", "env" ] }
-futures-util = "0.3.21"
 k8s-openapi = { version = "0.15.0", default-features = false, features = ["v1_24"] }
-hyper = { version = "0.14", features = ["full"] }
+warp = { version = "0.3.2", default_features = false, features = [ "multipart", "tls"] }
 num_cpus = "1.13.1"
 opentelemetry = { version = "0.17", default-features = false, features = ["metrics", "trace", "rt-tokio", "serialize"] }
 opentelemetry-otlp = { version = "0.10.0", features = ["metrics", "tonic"] }
-rustls = "0.20.6"
-rustls-pemfile = "1.0.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.24"
 tokio = { version = "^1", features = ["full"] }
-tokio-rustls = "0.23.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
 tracing-futures = "0.2"

--- a/src/admission_review.rs
+++ b/src/admission_review.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use policy_evaluator::admission_response::AdmissionResponse;
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub(crate) struct GroupVersionKind {
@@ -12,6 +12,42 @@ pub(crate) struct GroupVersionResource {
     pub group: String,
     pub version: String,
     pub resource: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AdmissionReview {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request: Option<AdmissionRequest>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response: Option<AdmissionResponse>,
+}
+
+impl AdmissionReview {
+    pub fn new_with_response(response: AdmissionResponse) -> Self {
+        AdmissionReview {
+            response: Some(response),
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for AdmissionReview {
+    fn default() -> Self {
+        AdmissionReview {
+            api_version: Some(String::from("admission.k8s.io/v1")),
+            kind: Some(String::from("AdmissionReview")),
+            request: None,
+            response: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -44,73 +80,17 @@ pub(crate) struct AdmissionRequest {
     pub options: Option<k8s_openapi::apimachinery::pkg::runtime::RawExtension>,
 }
 
-impl AdmissionRequest {
-    pub(crate) fn new(raw: hyper::body::Bytes) -> Result<AdmissionRequest> {
-        let obj: serde_json::Value = match serde_json::from_slice(&raw) {
-            Ok(obj) => obj,
-            Err(e) => return Err(anyhow!("Error parsing request: {:?}", e)),
-        };
-
-        let req = match obj.get("request") {
-            Some(req) => req,
-            None => return Err(anyhow!("Cannot parse AdmissionReview: 'request' not found")),
-        };
-        let admission_request: AdmissionRequest = serde_json::from_value(req.clone())?;
-        Ok(admission_request)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::body::Bytes;
     use std::collections::BTreeMap;
 
     #[test]
-    fn invalid_input() {
-        let input = Bytes::from("this is not the JSON you're looking for");
-
-        let res = AdmissionRequest::new(input);
-        assert!(res.is_err());
-    }
-
-    #[test]
-    fn missing_request() {
-        let input = Bytes::from(
-            r#"
-            { "foo": "bar" }
-        "#,
-        );
-
-        let res = AdmissionRequest::new(input);
-        assert!(res.is_err());
-    }
-
-    #[test]
-    fn missing_uid() {
-        let input = Bytes::from(
-            r#"
-            { 
-                "request": {
-                    "foo": "bar"
-                }
-            }
-        "#,
-        );
-
-        let res = AdmissionRequest::new(input);
-        assert!(res.is_err());
-    }
-
-    #[test]
     fn good_input() {
-        let input = Bytes::from(
-            r#"
+        let input = r#"
             { 
                 "request": {
                     "uid": "hello",
-                    "foo": "bar",
-
                     "kind": {"group":"autoscaling","version":"v1","kind":"Scale"},
                     "resource": {"group":"apps","version":"v1","resource":"deployments"},
                     "subResource": "scale",
@@ -134,43 +114,41 @@ mod tests {
                     "dryRun": false
                 }
             }
-        "#,
-        );
+        "#;
 
-        let res = AdmissionRequest::new(input);
-        assert!(!res.is_err());
+        let ar: AdmissionReview = serde_json::from_str(input).expect("deserialization should work");
+        let request = ar.request.expect("request should be set");
 
-        let ar = res.unwrap();
-        assert_eq!(ar.uid, "hello");
-        assert_eq!(ar.name.unwrap(), "my-deployment");
-        assert_eq!(ar.namespace.unwrap(), "my-namespace");
-        assert_eq!(ar.operation, "UPDATE");
-        assert_eq!(ar.sub_resource.unwrap(), "scale");
-        assert_eq!(ar.kind.group, "autoscaling");
-        assert_eq!(ar.kind.version, "v1");
-        assert_eq!(ar.kind.kind, "Scale");
-        assert_eq!(ar.resource.resource, "deployments");
-        assert_eq!(ar.resource.group, "apps");
-        assert_eq!(ar.resource.version, "v1");
-        assert_eq!(ar.resource.version, "v1");
+        assert_eq!(request.uid, "hello");
+        assert_eq!(request.name.unwrap(), "my-deployment");
+        assert_eq!(request.namespace.unwrap(), "my-namespace");
+        assert_eq!(request.operation, "UPDATE");
+        assert_eq!(request.sub_resource.unwrap(), "scale");
+        assert_eq!(request.kind.group, "autoscaling");
+        assert_eq!(request.kind.version, "v1");
+        assert_eq!(request.kind.kind, "Scale");
+        assert_eq!(request.resource.resource, "deployments");
+        assert_eq!(request.resource.group, "apps");
+        assert_eq!(request.resource.version, "v1");
+        assert_eq!(request.resource.version, "v1");
 
-        assert!(!ar.dry_run.unwrap());
-        assert_eq!(ar.request_sub_resource.unwrap(), "scale");
-        assert!(ar.request_kind.is_some());
-        let request_kind = ar.request_kind.unwrap();
+        assert!(!request.dry_run.unwrap());
+        assert_eq!(request.request_sub_resource.unwrap(), "scale");
+        assert!(request.request_kind.is_some());
+        let request_kind = request.request_kind.unwrap();
         assert_eq!(request_kind.group, "autoscaling");
         assert_eq!(request_kind.version, "v1");
         assert_eq!(request_kind.kind, "Scale");
-        assert!(ar.request_resource.is_some());
-        let request_resource = ar.request_resource.unwrap();
+        assert!(request.request_resource.is_some());
+        let request_resource = request.request_resource.unwrap();
         assert_eq!(request_resource.group, "apps");
         assert_eq!(request_resource.version, "v1");
         assert_eq!(request_resource.resource, "deployments");
 
-        assert_eq!(ar.user_info.username.unwrap(), "admin");
-        assert_eq!(ar.user_info.uid.unwrap(), "014fbff9a07c");
+        assert_eq!(request.user_info.username.unwrap(), "admin");
+        assert_eq!(request.user_info.uid.unwrap(), "014fbff9a07c");
         assert_eq!(
-            ar.user_info.groups.unwrap(),
+            request.user_info.groups.unwrap(),
             vec!["system:authenticated", "my-admin-group"]
         );
         let mut expected_extra_values = BTreeMap::new();
@@ -178,26 +156,26 @@ mod tests {
             String::from("some-key"),
             vec![String::from("some-value1"), String::from("some-value2")],
         );
-        assert_eq!(ar.user_info.extra.unwrap(), expected_extra_values);
+        assert_eq!(request.user_info.extra.unwrap(), expected_extra_values);
 
-        assert!(ar.object.is_some());
-        let object = ar.object.unwrap();
+        assert!(request.object.is_some());
+        let object = request.object.unwrap();
         assert_eq!(
             object.0.get("apiVersion").unwrap().as_str().unwrap(),
             "autoscaling/v1"
         );
         assert_eq!(object.0.get("kind").unwrap().as_str().unwrap(), "Scale");
 
-        assert!(ar.old_object.is_some());
-        let old_object = ar.old_object.unwrap();
+        assert!(request.old_object.is_some());
+        let old_object = request.old_object.unwrap();
         assert_eq!(
             old_object.0.get("apiVersion").unwrap().as_str().unwrap(),
             "autoscaling/v1"
         );
         assert_eq!(old_object.0.get("kind").unwrap().as_str().unwrap(), "Scale");
 
-        assert!(ar.options.is_some());
-        let options = ar.options.unwrap();
+        assert!(request.options.is_some());
+        let options = request.options.unwrap();
         assert_eq!(
             options.0.get("apiVersion").unwrap().as_str().unwrap(),
             "meta.k8s.io/v1"

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use policy_evaluator::validation_response::ValidationResponse;
+use policy_evaluator::admission_response::AdmissionResponse;
 use std::collections::HashMap;
 use tokio::sync::oneshot;
 
@@ -10,7 +10,7 @@ use crate::settings::Policy;
 pub(crate) struct EvalRequest {
     pub policy_id: String,
     pub req: AdmissionRequest,
-    pub resp_chan: oneshot::Sender<Option<ValidationResponse>>,
+    pub resp_chan: oneshot::Sender<Option<AdmissionResponse>>,
     pub parent_span: tracing::Span,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,18 +304,15 @@ fn main() -> Result<()> {
 
         // All is good, we can start listening for incoming requests through the
         // web server
-        let tls_acceptor = if cert_file.is_empty() {
+        let tls_config = if cert_file.is_empty() {
             None
         } else {
-            match server::new_tls_acceptor(&cert_file, &key_file) {
-                Ok(t) => Some(t),
-                Err(e) => {
-                    fatal_error(format!("error while creating tls acceptor: {:?}", e));
-                    unreachable!();
-                }
-            }
+            Some(crate::server::TlsConfig {
+                cert_file: cert_file.to_string(),
+                key_file: key_file.to_string(),
+            })
         };
-        server::run_server(&addr, tls_acceptor, api_tx).await;
+        server::run_server(&addr, tls_config, api_tx).await;
 
         // The evaluation is done, we can shutdown the tokio task that is running
         // the CallbackHandler

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,96 +1,61 @@
-use anyhow::{anyhow, Result};
-use async_stream::stream;
+use std::net::SocketAddr;
+use tokio::sync::mpsc::Sender;
 
-use futures_util::future::TryFutureExt;
-use hyper::{
-    server::accept,
-    service::{make_service_fn, service_fn},
-    Server,
-};
-use rustls::server::ServerConfig;
-use rustls_pemfile::{certs, rsa_private_keys};
-use std::{io, io::Cursor, net::SocketAddr, sync::Arc};
-use tokio::{net::TcpListener, sync::mpsc::Sender};
-use tokio_rustls::TlsAcceptor;
-use tracing::{error, info};
-
-use crate::api;
 use crate::communication::EvalRequest;
 
-pub(crate) fn new_tls_acceptor(cert_file: &str, key_file: &str) -> Result<TlsAcceptor> {
-    let mut cert_buff = Cursor::new(
-        std::fs::read(cert_file)
-            .map_err(|e| anyhow!("Error opening certificate file {}: {:?}", cert_file, e))?,
-    );
-    let cert = certs(&mut cert_buff)?
-        .into_iter()
-        .map(rustls::Certificate)
-        .collect();
-    let mut key_buff = Cursor::new(
-        std::fs::read(key_file)
-            .map_err(|e| anyhow!("Error opening key file {}: {:?}", cert_file, e))?,
-    );
-    let key = rsa_private_keys(&mut key_buff)?;
-    if key.len() != 1 {
-        return Err(anyhow!("Key file has to contain only one private key"));
-    }
-    let key = rustls::PrivateKey(key.into_iter().next().unwrap());
-
-    let server_config = ServerConfig::builder()
-        .with_safe_defaults()
-        .with_no_client_auth()
-        .with_single_cert(cert, key)
-        .expect("bad certificate/key");
-
-    Ok(TlsAcceptor::from(Arc::new(server_config)))
+pub(crate) struct TlsConfig {
+    pub cert_file: String,
+    pub key_file: String,
 }
 
 pub(crate) async fn run_server(
     addr: &SocketAddr,
-    tls_acceptor: Option<TlsAcceptor>,
+    tls_config: Option<TlsConfig>,
     api_tx: Sender<EvalRequest>,
 ) {
-    macro_rules! mk_svc_fn {
-        ($tx:expr) => {
-            make_service_fn(|_conn| {
-                let svc_tx = $tx.clone();
-                async move {
-                    Ok::<_, hyper::Error>(service_fn(move |req| api::route(req, svc_tx.clone())))
-                }
-            })
-        };
-    }
+    let ip = addr.ip();
+    let port = addr.port();
 
-    match tls_acceptor {
-        None => {
-            let make_svc = mk_svc_fn!(api_tx);
-            let server = Server::bind(addr).serve(make_svc);
-            info!(address = addr.to_string().as_str(), "started HTTP server");
-            if let Err(e) = server.await {
-                error!(error = e.to_string().as_str(), "HTTP server error");
-            }
-        }
-        Some(tls_acceptor) => {
-            let tcp = TcpListener::bind(&addr).await.unwrap();
-            let incoming_tls_stream = stream! {
-                loop {
-                    let (socket, _) = tcp.accept().await?;
-                    let stream = tls_acceptor.accept(socket).map_err(|e| {
-                        error!("[!] Voluntary server halt due to client-connection error...");
-                        io::Error::new(io::ErrorKind::Other, e)
-                    });
-                    yield stream.await;
-                }
-            };
+    let routes = filters::routes(api_tx);
 
-            let acceptor = accept::from_stream(incoming_tls_stream);
-            let make_svc = mk_svc_fn!(api_tx);
-            let server = Server::builder(acceptor).serve(make_svc);
-
-            info!(address = addr.to_string().as_str(), "started HTTPS server");
-            if let Err(e) = server.await {
-                error!(error = e.to_string().as_str(), "HTTPS server error");
-            }
+    match tls_config {
+        None => warp::serve(routes).run((ip, port)).await,
+        Some(cfg) => {
+            warp::serve(routes)
+                .tls()
+                .cert_path(cfg.cert_file)
+                .key_path(cfg.key_file)
+                .run((ip, port))
+                .await
         }
     };
+}
+
+mod filters {
+    use super::{EvalRequest, Sender};
+    use warp::Filter;
+
+    pub(crate) fn routes(
+        api_tx: Sender<EvalRequest>,
+    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+        validate(api_tx).or(readiness())
+    }
+
+    fn validate(
+        api_tx: Sender<EvalRequest>,
+    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+        // POST /validate/:policy_id with JSON body
+        warp::path!("validate" / String)
+            .and(warp::post())
+            .and(warp::body::json())
+            .and(warp::any().map(move || api_tx.clone()))
+            .and_then(crate::api::validation)
+    }
+
+    fn readiness() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+        // GET /readiness
+        warp::path!("readiness")
+            .and(warp::get())
+            .and_then(crate::api::readiness)
+    }
 }


### PR DESCRIPTION
Prior to this commit, we used the low level hyper to create our HTTP server. The code being used was pretty complex due to the low level nature of this library.
Moreover, the code wasn't robus enough. In certain cases the HTTP server could fail and cause the whole policy-server to drop incoming requests.

This kind of failures was hard to reproduce, but some users have run into that.

I was able to reproduce that too with minikube. Malformed client TLS requests could cause the server to reject them and then enter an error state.

Instead of implementing all the possible workarounds for these kind of situations, this code now implements the HTTP and HTTPS server using the warp crate.

Warp is built on top of hyper, but provides a ready to be consumed high level API.
Our core business is not implementing HTTP(s) servers, hence by using this library we make our code more robust and improve its overall quality.

As a matter of fact, thanks to this change, a lot of obscure code and repetitive one has been dropped.
Also, a lot of top level dependencies have been removed, because they are now pulled via warp.

FIXES https://github.com/kubewarden/policy-server/issues/239
