### PR TITLE
[feat] allow text logs to not have color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.24"
 tokio = { version = "^1", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
+tracing-subscriber = { version = "0.3", features = ["ansi", "fmt", "json"] }
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.17.4"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,9 +60,9 @@ pub(crate) fn build_cli() -> Command<'static> {
             Arg::new("log-no-color")
                 .long("log-no-color")
                 .takes_value(false)
-                .env("KUBEWARDEN_LOG_NO_COLOR")
+                .env("NO_COLOR")
                 .required(false)
-                .help("Disable colored output for logs [env: KUBEWARDEN_LOG_NO_COLOR=]"),
+                .help("Disable colored output for logs [env: NO_COLOR=]"),
         )
         .arg(
             Arg::new("address")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,7 @@ pub(crate) fn build_cli() -> Command<'static> {
                 .takes_value(false)
                 .env("NO_COLOR")
                 .required(false)
-                .help("Disable colored output for logs [env: NO_COLOR=]"),
+                .help("Disable colored output for logs"),
         )
         .arg(
             Arg::new("address")
@@ -109,10 +109,7 @@ pub(crate) fn build_cli() -> Command<'static> {
                 .takes_value(true)
                 .env("KUBEWARDEN_POLICIES")
                 .default_value("policies.yml")
-                .help(
-                    "YAML file holding the policies to be loaded and
-                    their settings",
-                ),
+                .help("YAML file holding the policies to be loaded and their settings"),
         )
         .arg(
             Arg::new("policies-download-dir")
@@ -158,7 +155,7 @@ pub(crate) fn build_cli() -> Command<'static> {
                 .takes_value(false)
                 .env("KUBEWARDEN_ENABLE_METRICS")
                 .required(false)
-                .help("Enable metrics [env: KUBEWARDEN_ENABLE_METRICS=]"),
+                .help("Enable metrics"),
         )
         .arg(
             Arg::new("enable-verification")
@@ -166,7 +163,7 @@ pub(crate) fn build_cli() -> Command<'static> {
                 .takes_value(false)
                 .env("KUBEWARDEN_ENABLE_VERIFICATION")
                 .required(false)
-                .help("Enable Sigstore verification [env: KUBEWARDEN_ENABLE_VERIFICATION=]"),
+                .help("Enable Sigstore verification"),
         )
         .arg(
             Arg::new("always-accept-admission-reviews-on-namespace")
@@ -174,7 +171,7 @@ pub(crate) fn build_cli() -> Command<'static> {
                 .takes_value(true)
                 .env("KUBEWARDEN_ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE")
                 .required(false)
-                .help("Always accept AdmissionReviews that target the given namespace [env: KUBEWARDEN_ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE]"),
+                .help("Always accept AdmissionReviews that target the given namespace"),
         )
         .long_version(VERSION_AND_BUILTINS.as_str())
 }


### PR DESCRIPTION
Allow user to have the default `text` log produce entries that are not colored.

This can be done in two ways:
  * Via the `--log-no-color` flag
  * By setting the following environment variable: `KUBEWARDEN_LOG_NO_COLOR=1`
