### PR TITLE
Prometheus metrics fixes 

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -25,7 +25,6 @@ pub(crate) fn init_meter() -> metrics::Result<PushController> {
 pub struct PolicyEvaluation {
     pub(crate) policy_name: String,
     pub(crate) policy_mode: String,
-    pub(crate) resource_name: String,
     pub(crate) resource_kind: String,
     pub(crate) resource_namespace: Option<String>,
     pub(crate) resource_request_operation: String,
@@ -40,7 +39,6 @@ impl Into<Vec<KeyValue>> for &PolicyEvaluation {
         let mut baggage = vec![
             KeyValue::new("policy_name", self.policy_name.clone()),
             KeyValue::new("policy_mode", self.policy_mode.clone()),
-            KeyValue::new("resource_name", self.resource_name.clone()),
             KeyValue::new("resource_kind", self.resource_kind.clone()),
             KeyValue::new(
                 "resource_request_operation",

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -233,10 +233,10 @@ impl Worker {
                         let policy_mode = policy_mode.clone();
                         let start_time = Instant::now();
                         let allowed_to_mutate = *allowed_to_mutate;
-                        let validation_response =
+                        let vanilla_validation_response =
                             policy_evaluator.validate(ValidateRequest::new(json));
                         let policy_evaluation_duration = start_time.elapsed();
-                        let error_code = if let Some(status) = &validation_response.status {
+                        let error_code = if let Some(status) = &vanilla_validation_response.status {
                             status.code
                         } else {
                             None
@@ -245,7 +245,7 @@ impl Worker {
                             &req.policy_id,
                             &policy_mode,
                             allowed_to_mutate,
-                            validation_response,
+                            vanilla_validation_response.clone(),
                         );
                         let validation_response =
                             // If the policy server is configured to
@@ -268,8 +268,8 @@ impl Worker {
                             } else {
                                 validation_response
                             };
-                        let accepted = validation_response.allowed;
-                        let mutated = validation_response.patch.is_some();
+                        let accepted = vanilla_validation_response.allowed;
+                        let mutated = vanilla_validation_response.patch.is_some();
                         let res = req.resp_chan.send(Some(validation_response));
                         let policy_evaluation = metrics::PolicyEvaluation {
                             policy_name,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -274,7 +274,6 @@ impl Worker {
                         let policy_evaluation = metrics::PolicyEvaluation {
                             policy_name,
                             policy_mode: policy_mode.into(),
-                            resource_name: req.req.name.unwrap_or_else(|| "unknown".to_string()),
                             resource_namespace: req.req.namespace,
                             resource_kind: req.req.request_kind.unwrap_or_default().kind,
                             resource_request_operation: req.req.operation.clone(),


### PR DESCRIPTION
Updates the worker code used to run the policy evaluation to use the vanilla admission response from the policy in the metrics. Thus, the users will be able to actually see what policies are doing before the values updates in monitor and protect modes.

Remove the `resource_name` from the prometheus metrics to avoid too much time series, reducing the data stored and simplifying the query used to extract information from the metrics. This is a best practice:  https://prometheus.io/docs/practices/naming/

Fixes #263 