### PR TITLE
Road to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
-<a name="v1.0.1"></a>
-## [v1.0.1] - 2022-06-24
+
+<a name="v1.1.0"></a>
+## [v1.1.0] - 2022-07-14
 ### Bug Fixes
+- cleanup of help output
 - keyless image verification
+- handle all the HTTP server code via warp
+- **deps:** update all patchlevel dependencies
+- **deps:** update all patchlevel dependencies
+
+### Pull Requests
+- Merge pull request [#284](https://github.com/kubewarden/policy-server/issues/284) from kubewarden/renovate/lock-file-maintenance
+- Merge pull request [#283](https://github.com/kubewarden/policy-server/issues/283) from kubewarden/renovate/all-patch
+- Merge pull request [#285](https://github.com/kubewarden/policy-server/issues/285) from flavio/log-allow-no-color-text-output
+- Merge pull request [#282](https://github.com/kubewarden/policy-server/issues/282) from flavio/update-to-latest-policy-evaluator
+- Merge pull request [#280](https://github.com/kubewarden/policy-server/issues/280) from kubewarden/renovate/all-patch
+- Merge pull request [#279](https://github.com/kubewarden/policy-server/issues/279) from raulcabello/main
+- Merge pull request [#278](https://github.com/kubewarden/policy-server/issues/278) from raulcabello/main
+- Merge pull request [#277](https://github.com/kubewarden/policy-server/issues/277) from flavio/v1.0.0-release
+- Merge pull request [#276](https://github.com/kubewarden/policy-server/issues/276) from flavio/cleanup-http-server
+
 
 <a name="v1.0.0-rc2"></a>
 ## [v1.0.0-rc2] - 2022-06-15
@@ -324,7 +341,8 @@
 - Merge pull request [#9](https://github.com/kubewarden/policy-server/issues/9) from cmurphy/fix-uid
 
 
-[Unreleased]: https://github.com/kubewarden/policy-server/compare/v1.0.0-rc2...HEAD
+[Unreleased]: https://github.com/kubewarden/policy-server/compare/v1.1.0...HEAD
+[v1.1.0]: https://github.com/kubewarden/policy-server/compare/v1.0.0-rc2...v1.1.0
 [v1.0.0-rc2]: https://github.com/kubewarden/policy-server/compare/v1.0.0-rc1...v1.0.0-rc2
 [v1.0.0-rc1]: https://github.com/kubewarden/policy-server/compare/v0.3.2...v1.0.0-rc1
 [v0.3.2]: https://github.com/kubewarden/policy-server/compare/v0.3.1...v0.3.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-server"
-version = "1.0.1"
+version = "1.1.0"
 authors = [
   "Flavio Castelli <fcastelli@suse.com>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
run `TAG=v1.1.0 make tag` Bump to v1.1.0, update changelog.

I don't have perms to push commits directly to main, but I have perms to push the tag.

Which means that the tag is pointing to https://github.com/kubewarden/policy-server/commit/5cec93f8096ceeb21975b3917018fb33e22dc645 even if it hasn't landed in main.

I have cancelled the GHA workflows. They could be retriggered again.

Either merge this, or delete tag, run `TAG=v1.1.0 make tag`, and push everything to main.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

