### PR TITLE
fix: create SBOM for tagged container image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -188,11 +188,19 @@ jobs:
         run: |
           mkdir policy-server-container-image-sbom
 
-      - name: Create SBOM file for the container image
+      - name: Create SBOM file for the latest container image
+        if: ${{ startsWith(github.ref, 'refs/heads/') }}
         shell: bash
         run: |
           set -e
           bom generate -n https://kubewarden.io/ --image ghcr.io/${{ github.repository_owner }}/policy-server@${{ steps.build-latest.outputs.digest }} -o policy-server-container-image-sbom/policy-server-container-image-sbom.spdx
+
+      - name: Create SBOM file for the tagged container image
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        shell: bash
+        run: |
+          set -e
+          bom generate -n https://kubewarden.io/ --image ghcr.io/${{ github.repository_owner }}/policy-server@${{ steps.build-tag.outputs.digest }} -o policy-server-container-image-sbom/policy-server-container-image-sbom.spdx
 
       - name: Sign container image SBOM file
         run: |


### PR DESCRIPTION
Ensure the SBOM for the tagged container image (like `policy-server:2.0.0`) is created.

Prior to this commit, the creation of the SBOM failed because the signing action was trying to obain the digest of the `latest` container image.

This fixes build errors like this one: https://github.com/kubewarden/policy-server/actions/runs/3298307317/jobs/5440643528

