### PR TITLE
fix: ensure container image has the binary

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -131,7 +131,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Download artifacts
         id: download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
+      - name: Move artifacts to project root
+        run: |
+          mv -v policy-server/* .
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
Sometimes ago we upgraded the `actions/download-artifact` action to a major tag (v1 -> v2), this changes the behaviour used when extracting the artifacts.

That causes the container image to have `/policy-server/policy-server-x86_64` instead of `/policy-server`
