### PR TITLE
fix: have a working container image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -129,44 +129,82 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Download artifacts
-        id: download
+
+      # Download the policy-server binaries we've built inside of the previous job
+      - name: Download policy-server-x86_64 binary
         uses: actions/download-artifact@v3
-      - name: Move artifacts to project root
-        run: |
-          mv -v policy-server/* .
+        with:
+          name: policy-server-x86_64
+      - name: Download policy-server-aarch64 binary
+        uses: actions/download-artifact@v3
+        with:
+          name: policy-server-aarch64
+
+      # Prepare docker environment
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push development container image
+
+      # Build and push `latest` image
+      - name: Build and export to docker
+        if: ${{ startsWith(github.ref, 'refs/heads/') }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/policy-server:latest
+      - name: Test container image
+        if: ${{ startsWith(github.ref, 'refs/heads/') }}
+        run: |
+          docker run --rm ghcr.io/${{ github.repository_owner }}/policy-server:latest --help
+      - name: Build and push
         if: ${{ startsWith(github.ref, 'refs/heads/') }}
         id: build-latest
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/policy-server:latest
+
+      # Build and push the `:<version>` image
       - name: Retrieve tag name
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           echo TAG_NAME=$(echo $GITHUB_REF | sed -e "s|refs/tags/||") >> $GITHUB_ENV
-      - name: Build and push tagged container image
+      - name: Build and export to docker
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/policy-server:${{ env.TAG_NAME }}
+      - name: Test container image
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          docker run --rm ghcr.io/${{ github.repository_owner }}/policy-server:${{ env.TAG_NAME }} --help
+      - name: Build and push
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         id: build-tag
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/policy-server:${{ env.TAG_NAME }}
+
+      # Sign the container image that has just been built
       - uses: sigstore/cosign-installer@main
       - name: Sign the images for releases
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -183,21 +221,19 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: 1
 
+      # Generate SBOM of the container image that has just been built
       - name: Install the bom command
         uses: kubewarden/github-actions/kubernetes-bom-installer@v1
-
       - name: Create directory to store container SBOM files
         shell: bash
         run: |
           mkdir policy-server-container-image-sbom
-
       - name: Create SBOM file for the latest container image
         if: ${{ startsWith(github.ref, 'refs/heads/') }}
         shell: bash
         run: |
           set -e
           bom generate -n https://kubewarden.io/ --image ghcr.io/${{ github.repository_owner }}/policy-server@${{ steps.build-latest.outputs.digest }} -o policy-server-container-image-sbom/policy-server-container-image-sbom.spdx
-
       - name: Create SBOM file for the tagged container image
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         shell: bash
@@ -205,6 +241,7 @@ jobs:
           set -e
           bom generate -n https://kubewarden.io/ --image ghcr.io/${{ github.repository_owner }}/policy-server@${{ steps.build-tag.outputs.digest }} -o policy-server-container-image-sbom/policy-server-container-image-sbom.spdx
 
+      # Sign SBOM files of the container image that has just been built
       - name: Sign container image SBOM file
         run: |
           cosign sign-blob --output-certificate policy-server-container-image-sbom/policy-server-container-image-sbom.spdx.cert \
@@ -213,18 +250,11 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: 1
 
-      - name: Upload policy-server x86_64 SBOM files
-        uses: actions/upload-artifact@v2
+      # Upload the SBOM files of the container image as assets
+      - name: Upload policy-server container image SBOM files
+        uses: actions/upload-artifact@v3
         with:
-          name: policy-server-x86_64-sbom
+          name: policy-server-container-image-sbom
           path: |
-            ${{steps.download.outputs.download-path}}/policy-server-x86_64-sbom
-            policy-server-container-image-sbom
+            policy-server-container-image-sbom/
 
-      - name: Upload policy-server aarch64 SBOM files
-        uses: actions/upload-artifact@v2
-        with:
-          name: policy-server-aarch64-sbom
-          path: |
-            ${{steps.download.outputs.download-path}}/policy-server-aarch64-sbom
-            policy-server-container-image-sbom


### PR DESCRIPTION
Ensure the resulting container image is working. Since we introduced the SBOM generation we caused a regression that lead the `policy-server` binary to be added to the final image under `/policy-server/policy-server-<arch>`.

That caused the resulting image to not work, because the entrypoint was a directory instead of a file.

This commit fixes the issue.

Moreover, the assets attached to the Release object have no duplicates inside of the Zip files. As a reference, take a look at this test release: https://github.com/flavio/policy-server/releases/tag/v1.3.0-fix22