### PR TITLE
chore: tell dependabot to look after github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     interval: daily
     time: "13:00"
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
A lot of our GH actions were not updated by renovatebot, dunno why.

Asking dependabot to look after them
