### PR TITLE
Artifacthub and OpenSSF badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kubewarden-defaults)](https://artifacthub.io/packages/helm/kubewarden/kubewarden-defaults)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6626/badge)](https://bestpractices.coreinfrastructure.org/projects/6626)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Fpolicy-server.svg?type=shield)](https://app.fossa.com/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Fpolicy-server?ref=badge_shield)
 
 > **Note well:** don't forget to checkout [Kubewarden's documentation](https://docs.kubewarden.io)


### PR DESCRIPTION
Adds Artifacthub badge pointing to the kubewarden-defaults Helm chart