### PR TITLE
fix: add binaries signatures to the same zip file

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -86,37 +86,30 @@ jobs:
           RUSTFLAGS: "-C link_arg=-lgcc -C link_arg=-specs -C link_arg=/usr/lib/${{ matrix.targetarch}}-linux-musl/musl-gcc.specs ${{ matrix.rustflags }}"
         run: |
           cargo build --release --target ${{ matrix.targetarch }}-unknown-linux-musl
-          mv target/${{ matrix.targetarch }}-unknown-linux-musl/release/policy-server policy-server-${{ matrix.targetarch }}
+          mkdir policy-server-${{ matrix.targetarch }}
+          mv target/${{ matrix.targetarch }}-unknown-linux-musl/release/policy-server policy-server-${{ matrix.targetarch }}/
 
       - name: Generate SBOM
         run: |
           spdx-sbom-generator -f json
           # SBOM files should have "sbom" in the name due the CLO monitor
           # https://clomonitor.io/docs/topics/checks/#software-bill-of-materials-sbom
-          mkdir policy-server-${{ matrix.targetarch }}-sbom
-          mv bom-cargo.json policy-server-${{ matrix.targetarch }}-sbom/policy-server-${{ matrix.targetarch }}-sbom.spdx.json
+          mv bom-cargo.json policy-server-${{ matrix.targetarch }}/policy-server.spdx.json
 
       - name: Sign BOM file
         run: |
-          cosign sign-blob --output-certificate policy-server-${{ matrix.targetarch }}-sbom/policy-server-${{ matrix.targetarch }}-sbom.spdx.cert \
-            --output-signature policy-server-${{ matrix.targetarch }}-sbom/policy-server-${{ matrix.targetarch }}-sbom.spdx.sig \
-            policy-server-${{ matrix.targetarch }}-sbom/policy-server-${{ matrix.targetarch }}-sbom.spdx.json
+          cosign sign-blob --output-certificate policy-server-${{ matrix.targetarch }}/policy-server.spdx.cert \
+            --output-signature policy-server-${{ matrix.targetarch }}/policy-server.spdx.sig \
+            policy-server-${{ matrix.targetarch }}/policy-server.spdx.json
         env:
           COSIGN_EXPERIMENTAL: 1
 
-      - name: Upload policy-server binary
+      - name: Upload policy-server directory
         uses: actions/upload-artifact@v3
         with:
           name: policy-server-${{ matrix.targetarch }}
           path: |
             policy-server-${{ matrix.targetarch }}
-
-      - name: Upload policy-server SBOM files
-        uses: actions/upload-artifact@v3
-        with:
-          name: policy-server-${{ matrix.targetarch }}-sbom
-          path: |
-            policy-server-${{ matrix.targetarch }}-sbom
 
   build-container-image:
     name: Build policy server container image
@@ -130,15 +123,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Download the policy-server binaries we've built inside of the previous job
-      - name: Download policy-server-x86_64 binary
+      # Download the policy-server artifacts we've built inside of the previous job
+      - name: Download policy-server-x86_64 artifacts
         uses: actions/download-artifact@v3
         with:
           name: policy-server-x86_64
-      - name: Download policy-server-aarch64 binary
+          path: artifacts-x86_64
+      - name: Download policy-server-aarch64 artifacts
         uses: actions/download-artifact@v3
         with:
           name: policy-server-aarch64
+          path: artifacts-aarch64
+      - name: Move binaries to project root
+        run: |
+          mv artifacts-x86_64/policy-server policy-server-x86_64
+          mv artifacts-aarch64/policy-server policy-server-aarch64
 
       # Prepare docker environment
       - name: Set up QEMU


### PR DESCRIPTION
Add the signagures of the `policy-server` binaries to the same zip file. Previously, they where put into a dedicated zip file.

This change is needed to make CLOMonitor that we are signing all our assets.
