### PR TITLE
Add read-all permission to all workflows

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -6,13 +6,11 @@ on:
     tags:
     - 'v*'
 
-# Declare default permissions as read only.
-permissions: read-all
-
 jobs:
   ci:
     # A branch is required, and cannot be dynamic - https://github.com/actions/runner/issues/1493
     uses: kubewarden/policy-server/.github/workflows/tests.yml@main
+    permissions: read-all
   build-policy-server-binaries:
     name: Build container image
     runs-on: ubuntu-22.04

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -5,6 +5,10 @@ on:
     - main
     tags:
     - 'v*'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   ci:
     # A branch is required, and cannot be dynamic - https://github.com/actions/runner/issues/1493

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,10 @@ on:
       - 'v*'
     branches:
       - 'main'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,11 @@ on:
     branches:
       - "v*"
 
-# Declare default permissions as read only.
-permissions: read-all
-
 jobs:
   release:
     name: Create release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - completed
     branches:
       - "v*"
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   release:
     name: Create release

--- a/.github/workflows/security-audit-cron.yml
+++ b/.github/workflows/security-audit-cron.yml
@@ -2,6 +2,10 @@ name: Security audit cron job
 on:
   schedule:
     - cron: '0 0 * * *'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-audit-reactive.yml
+++ b/.github/workflows/security-audit-reactive.yml
@@ -4,6 +4,10 @@ on:
     paths: 
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
 
 name: Continuous integration
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
Setting token permissions to read-only follows the principle of least privilege. This is important because attackers may use a compromised token with write access to push malicious code into the project. [More info](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)

This will increase our CLOMonitor score

Fix #359 