### PR TITLE
Trigger Helm chart release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,22 @@ jobs:
       - name: 'Unzip build artifacts'
         run: unzip -n "policy-server-*.zip" -d artifacts
 
+      - name: Get old release tag
+        id: get_old_release_tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let release = await github.rest.repos.getLatestRelease({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+            });
+
+            if (release.status  === 200 ) {
+              core.setOutput('release_tag', release.data.tag_name)
+              return
+            }
+            core.setFailed("Cannot find latest release")
+
       - name: Create release
         uses: softprops/action-gh-release@v1
         env:
@@ -52,3 +68,27 @@ jobs:
           prerelease: ${{ contains(github.event.workflow_run.head_branch, '-alpha') || contains(github.event.workflow_run.head_branch, '-beta') || contains(github.event.workflow_run.head_branch, '-rc') }}
           files: |
             artifacts/*
+
+      - name: Get new release tag
+        id: get_new_release_tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let release = await github.rest.repos.getLatestRelease({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+            });
+
+            if (release.status  === 200 ) {
+              core.setOutput('release_tag', release.data.tag_name)
+              return
+            }
+            core.setFailed("Cannot find latest release")
+
+      - name: Trigger chart update
+        uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
+        with:
+          token: ${{ secrets.WORKFLOW_PAT }}
+          repository: "${{github.repository_owner}}/helm-charts"
+          event-type: update-chart
+          client-payload: '{"version": "${{ steps.get_new_release_tag.outputs.release_tag }}", "oldVersion": "${{ steps.get_old_release_tag.outputs.release_tag }}", "repository": "${{ github.repository }}"}'


### PR DESCRIPTION
## Description

Updates the release CI job to trigger an event to the Helm chart repository to ensure that the major and minor releases will be in sync between all Kubewarden components.

Fix https://github.com/kubewarden/policy-server/issues/376