### PR TITLE
Fix release drafter autolabeler and exclude-labels.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,7 +20,7 @@ exclude-labels:
   - later
   - wontfix
   - kind/question
-  - skip-changelog
+  - release/skip-changelog
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
@@ -40,6 +40,8 @@ autolabeler:
     title: 'fix'
   - label: 'kind/chore'
     title: 'chore'
+  - label: 'area/dependencies'
+    title: 'build(deps)'
 
 version-resolver:
   major:


### PR DESCRIPTION
## Description

Updates the release drafter configuration file changing the label used to exclude a PR from the change log to `release/skip-changelog`.

Adds a new entry in the autolabel configuration to set the label `area/dependencies` when the PR title starts with `build(deps)`


