### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,7 +21,7 @@ lazy_static! {
         let builtins: String = burrego::get_builtins()
             .keys()
             .sorted()
-            .map(|builtin| format!("  - {}", builtin))
+            .map(|builtin| format!("  - {builtin}"))
             .join("\n");
 
         format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,10 +53,7 @@ fn main() -> Result<()> {
 
     let metrics_enabled = matches.contains_id("enable-metrics");
     let verification_config = cli::verification_config(&matches).unwrap_or_else(|e| {
-        fatal_error(format!(
-            "Cannot create sigstore verification config: {:?}",
-            e
-        ));
+        fatal_error(format!("Cannot create sigstore verification config: {e:?}"));
         unreachable!()
     });
     let sigstore_cache_dir = matches
@@ -75,8 +72,7 @@ fn main() -> Result<()> {
             Ok(v) => Some(v),
             Err(e) => {
                 fatal_error(format!(
-                    "'policy-timeout' value cannot be converted to unsigned int: {}",
-                    e
+                    "'policy-timeout' value cannot be converted to unsigned int: {e}"
                 ));
                 unreachable!()
             }
@@ -104,7 +100,7 @@ fn main() -> Result<()> {
         }
         match daemonize.start() {
             Ok(_) => println!("Detached from shell, now running in background."),
-            Err(e) => fatal_error(format!("Something went wrong while daemonizing: {}", e)),
+            Err(e) => fatal_error(format!("Something went wrong while daemonizing: {e}")),
         }
     }
 
@@ -133,7 +129,7 @@ fn main() -> Result<()> {
             // We cannot rely on `tracing` yet, because the tracing system has not
             // been initialized, this has to be done inside of an async block, which
             // we cannot use yet
-            eprintln!("Cannot fetch TUF repository: {:?}", e);
+            eprintln!("Cannot fetch TUF repository: {e:?}");
             eprintln!("Sigstore Verifier created without Fulcio data: keyless signatures are going to be discarded because they cannot be verified");
             eprintln!(
                 "Sigstore Verifier created without Rekor data: transparency log data won't be used"
@@ -203,8 +199,7 @@ fn main() -> Result<()> {
             Ok(p) => p,
             Err(e) => {
                 fatal_error(format!(
-                    "Cannot init dedicated tokio runtime for the Kubernetes poller: {:?}",
-                    e
+                    "Cannot init dedicated tokio runtime for the Kubernetes poller: {e:?}"
                 ));
                 unreachable!()
             }
@@ -225,7 +220,7 @@ fn main() -> Result<()> {
     let rt = match Runtime::new() {
         Ok(r) => r,
         Err(error) => {
-            fatal_error(format!("error initializing tokio runtime: {}", error));
+            fatal_error(format!("error initializing tokio runtime: {error}"));
             unreachable!();
         }
     };
@@ -389,11 +384,11 @@ fn main() -> Result<()> {
     });
 
     if let Err(e) = wasm_thread.join() {
-        fatal_error(format!("error while waiting for worker threads: {:?}", e));
+        fatal_error(format!("error while waiting for worker threads: {e:?}"));
     };
 
     if let Err(e) = kube_poller_thread.join() {
-        fatal_error(format!("error while waiting for worker threads: {:?}", e));
+        fatal_error(format!("error while waiting for worker threads: {e:?}"));
     };
 
     Ok(())
@@ -405,7 +400,7 @@ fn fatal_error(msg: String) {
         error!("{}", msg);
         shutdown_tracer_provider();
     } else {
-        eprintln!("{}", msg);
+        eprintln!("{msg}");
     }
 
     process::exit(1);

--- a/src/policy_downloader.rs
+++ b/src/policy_downloader.rs
@@ -111,7 +111,7 @@ impl Downloader {
                     Err(e) => {
                         info!(policy = name.as_str(), error =?e, "policy cannot be verified");
                         policy_verification_errors
-                            .push(format!("Policy '{}' cannot be verified: {:?}", name, e));
+                            .push(format!("Policy '{name}' cannot be verified: {e:?}"));
                         continue;
                     }
                 };
@@ -150,7 +150,7 @@ impl Downloader {
                         "cannot verify policy, missing verified manifest digest"
                     );
                     policy_verification_errors
-                            .push(format!("verification of policy {} cannot be done, missing verified manifest digest", name));
+                            .push(format!("verification of policy {name} cannot be done, missing verified manifest digest"));
                     continue;
                 }
 
@@ -167,7 +167,7 @@ impl Downloader {
                         "verification failed"
                     );
                     policy_verification_errors
-                        .push(format!("verification of policy {} failed: {}", name, e));
+                        .push(format!("verification of policy {name} failed: {e}"));
 
                     continue;
                 }
@@ -247,7 +247,7 @@ async fn create_verifier(
             // We cannot rely on `tracing` yet, because the tracing system has not
             // been initialized, this has to be done inside of an async block, which
             // we cannot use yet
-            eprintln!("Cannot fetch TUF repository: {:?}", e);
+            eprintln!("Cannot fetch TUF repository: {e:?}");
             eprintln!("Sigstore Verifier created without Fulcio data: keyless signatures are going to be discarded because they cannot be verified");
             eprintln!(
                 "Sigstore Verifier created without Rekor data: transparency log data won't be used"

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -34,7 +34,7 @@ impl fmt::Display for PolicyErrors {
         let mut errors = self
             .0
             .iter()
-            .map(|(policy, error)| format!("[{}: {}]", policy, error));
+            .map(|(policy, error)| format!("[{policy}: {error}]"));
         write!(f, "{}", errors.join(", "))
     }
 }
@@ -72,7 +72,7 @@ impl Worker {
                 Err(e) => {
                     evs_errors.insert(
                         id.clone(),
-                        format!("[{}] could not create PolicyEvaluator: {:?}", id, e),
+                        format!("[{id}] could not create PolicyEvaluator: {e:?}"),
                     );
                     continue;
                 }
@@ -117,7 +117,7 @@ impl Worker {
                     AdmissionResponse {
                         allowed: false,
                         status: Some(AdmissionResponseStatus {
-                            message: Some(format!("Request rejected by policy {}. The policy attempted to mutate the request, but it is currently configured to not allow mutations.", policy_id)),
+                            message: Some(format!("Request rejected by policy {policy_id}. The policy attempted to mutate the request, but it is currently configured to not allow mutations.")),
                             code: None,
                         }),
                         // if `allowed_to_mutate` is false, we are in a validating webhook. If we send a patch, k8s will fail because validating webhook do not expect this field
@@ -140,7 +140,7 @@ impl Worker {
                 info!(
                     policy_id = policy_id,
                     allowed_to_mutate = allowed_to_mutate,
-                    response = format!("{:?}", validation_response).as_str(),
+                    response = format!("{validation_response:?}").as_str(),
                     "policy evaluation (monitor mode)",
                 );
                 AdmissionResponse {
@@ -238,7 +238,7 @@ impl Worker {
                 res.map_err(|_| anyhow!("cannot send response back"))
             }
             Err(e) => {
-                let error_msg = format!("Failed to serialize AdmissionReview: {:?}", e);
+                let error_msg = format!("Failed to serialize AdmissionReview: {e:?}");
                 error!("{}", error_msg);
                 req.resp_chan
                     .send(Some(AdmissionResponse::reject(

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -103,10 +103,7 @@ impl WorkerPool {
         let bootstrap_data = match self.bootstrap_rx.blocking_recv() {
             Ok(data) => data,
             Err(e) => {
-                eprintln!(
-                    "workers pool bootstrap: error receiving bootstrap data: {:?}",
-                    e
-                );
+                eprintln!("workers pool bootstrap: error receiving bootstrap data: {e:?}");
                 std::process::exit(1);
             }
         };
@@ -121,10 +118,7 @@ impl WorkerPool {
         let engine = match wasmtime::Engine::new(&wasmtime_config) {
             Ok(e) => e,
             Err(e) => {
-                eprintln!(
-                    "workers pool bootstrap: cannot instantiate `wasmtime::Engine`: {:?}",
-                    e
-                );
+                eprintln!("workers pool bootstrap: cannot instantiate `wasmtime::Engine`: {e:?}");
                 std::process::exit(1);
             }
         };
@@ -133,7 +127,7 @@ impl WorkerPool {
             match precompile_policies(&engine, &bootstrap_data.fetched_policies) {
                 Ok(pp) => pp,
                 Err(e) => {
-                    eprintln!("{}", e);
+                    eprintln!("{e}");
                     std::process::exit(1);
                 }
             };
@@ -183,10 +177,7 @@ impl WorkerPool {
                         )))
                         .is_err()
                     {
-                        eprint!(
-                            "cannot create wasmtime engine for one of the workers: {}",
-                            e
-                        );
+                        eprint!("cannot create wasmtime engine for one of the workers: {e}");
                         std::process::exit(1);
                     };
                     return;
@@ -352,8 +343,7 @@ fn precompile_policies(
         .filter_map(|(url, result)| match result {
             Ok(_) => None,
             Err(e) => Some(format!(
-                "[{}] policy cannot be compiled to WebAssembly module: {:?}",
-                url, e
+                "[{url}] policy cannot be compiled to WebAssembly module: {e:?}"
             )),
         })
         .collect();
@@ -415,7 +405,7 @@ fn verify_policy_settings(
         ) {
             Ok(pe) => pe,
             Err(e) => {
-                errors.push(format!("[{}] cannot create PolicyEvaluator: {:?}", id, e));
+                errors.push(format!("[{id}] cannot create PolicyEvaluator: {e:?}"));
                 continue;
             }
         };


### PR DESCRIPTION
Get rid of clippy warnings generated by the latest version of rust
