### PR TITLE
chore: ignore daemonize not being maintained

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -11,4 +11,6 @@ ignore = [
                        # This is a transitive dependency of `multipart`, which is
                        # a dependency of `warp`. This is the GH issue that describes
                        # the problem: # https://github.com/abonander/multipart/issues/143
+  "RUSTSEC-2021-0147", # This is about "daemonize" being unmaintained.
+                       # This is a feature that we use only when doing e2e tests
 ]


### PR DESCRIPTION
Instruct cargo-audit to not complain about the `daemonize` crate being unmaintained. This is being used only inside of the e2e tests.
