### PR TITLE
fix: make e2e tests more scrupulous

### DIFF
--- a/e2e-tests/02-monitor-and-protect-modes.yml
+++ b/e2e-tests/02-monitor-and-protect-modes.yml
@@ -23,6 +23,7 @@ testcases:
     assertions:
     - result.statuscode ShouldEqual 200
     - result.bodyjson.response.allowed ShouldEqual false
+    - result.bodyjson.response.status.code ShouldNotEqual 500
 
 - name: The `/validate` endpoint accepts the request because it's in `monitor` mode
   steps:

--- a/e2e-tests/03-audit-endpoint.yml
+++ b/e2e-tests/03-audit-endpoint.yml
@@ -35,3 +35,4 @@ testcases:
       assertions:
       - result.statuscode ShouldEqual 200
       - result.bodyjson.response.allowed ShouldEqual false
+      - result.bodyjson.response.status.code ShouldNotEqual 500

--- a/e2e-tests/04-timeout-protection.yml
+++ b/e2e-tests/04-timeout-protection.yml
@@ -45,6 +45,8 @@ testcases:
       assertions:
       - result.statuscode ShouldEqual 200
       - result.bodyjson.response.allowed ShouldEqual false
+      - result.bodyjson.response.status.code ShouldEqual 500
+      - result.bodyjson.response.status.message ShouldContainSubstring "execution deadline exceeded"
       - result.timeseconds ShouldBeLessThan 3
 
 - name: Accept AGAIN a request that has a short evaluation time

--- a/e2e-tests/05-rego-policy.yml
+++ b/e2e-tests/05-rego-policy.yml
@@ -21,7 +21,8 @@ testcases:
 
 - name: Rego-based policies work as expected
   steps:
-  - type: http
+  - name: Send violating request
+    type: http
     method: POST
     url: http://localhost:3000/validate/disallow-service-loadbalancer
     headers:
@@ -30,7 +31,9 @@ testcases:
     assertions:
     - result.statuscode ShouldEqual 200
     - result.bodyjson.response.allowed ShouldEqual false
-  - type: http
+    - result.bodyjson.response.status.code ShouldNotEqual 500
+  - name: Send non violating request
+    type: http
     method: POST
     url: http://localhost:3000/validate/disallow-service-loadbalancer
     headers:


### PR DESCRIPTION
Extend the tests to look also at the reason that lead a request to be rejected.

This would have allowed us to spot https://github.com/kubewarden/policy-evaluator/issues/239
ahead of time.

**Note:** the e2e tests of this PR will keep failing until the update policy-evaluator to include the fix of the bug linked above. That's a feature :smile:

