### PR TITLE
deps: Pin cosign to 1.* by pinning cosign-installer GHA

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -31,7 +31,7 @@ jobs:
       - ci
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v2.8.1
 
       - name: Install SBOM generator tool
         uses: kubewarden/github-actions/sbom-generator-installer@v1
@@ -206,7 +206,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/policy-server:${{ env.TAG_NAME }}
 
       # Sign the container image that has just been built
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@v2.8.1
       - name: Sign the images for releases
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |


### PR DESCRIPTION
## Description

Cosign 2.0 was [released last week](https://blog.sigstore.dev/cosign-2-0-released/) (yay!) but, as expected because semver, it's not backwards compatible (nay!).

Pin cosign-installer GHA so it downloads cosign 1.*.
Latest [cosign-installer downloads cosign 2.*](https://github.com/sigstore/cosign-installer/releases/tag/v3.0.0).


## Test

Tested in other repos.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
