### PR TITLE
chore: fix cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,4 +13,7 @@ ignore = [
                        # the problem: # https://github.com/abonander/multipart/issues/143
   "RUSTSEC-2021-0147", # This is about "daemonize" being unmaintained.
                        # This is a feature that we use only when doing e2e tests
+  "RUSTSEC-2020-0168", # This is about "mach" being unmaintained.
+                       # This is a transitive dependency of wasmtime. This is
+                       # being tracked upstream via https://github.com/bytecodealliance/wasmtime/issues/6000
 ]


### PR DESCRIPTION
cargo-audit is complaining because the `mach` dependency is currently not maintained.

This is a transitive dependency of wasmtime.
The issue is tracked upstream via https://github.com/bytecodealliance/wasmtime/issues/6000

In the meantime we will silence this warning.
