### PR TITLE
Check minimum Kubewarden version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,6 +3291,7 @@ dependencies = [
  "policy-evaluator",
  "rayon",
  "rstest",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tracing-futures = "0.2"
 tracing-opentelemetry = "0.17.4"
 tracing-subscriber = { version = "0.3", features = ["ansi", "fmt", "json"] }
 warp = { version = "0.3.4", default_features = false, features = [ "multipart", "tls"] }
+semver = { version = "1.0.17", features = ["serde"] }
 
 [dev-dependencies]
 rstest = "0.17"

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use core::time;
+use lazy_static::lazy_static;
 use policy_evaluator::{
     callback_requests::CallbackRequest,
     policy_evaluator::{Evaluator, PolicyEvaluator, PolicyExecutionMode},
@@ -8,6 +9,7 @@ use policy_evaluator::{
     wasmtime,
 };
 use rayon::prelude::*;
+use semver::{BuildMetadata, Prerelease, Version};
 use std::{
     collections::HashMap,
     fs,
@@ -45,13 +47,50 @@ pub(crate) struct PrecompiledPolicy {
     /// The execution mode of the policy
     pub execution_mode: PolicyExecutionMode,
 }
+lazy_static! {
+    static ref KUBEWARDEN_VERSION: Version = {
+        let mut version = Version::parse(env!("CARGO_PKG_VERSION")).expect("Cannot parse CARGO_PKG_VERSION version");
+        // Remove the patch, prerelease and build information to avoid rejections
+        // like this: v1.6.0-rc4 < v1.6.0
+        version.patch = 0;
+        version.pre = Prerelease::EMPTY;
+        version.build = BuildMetadata::EMPTY;
+        version
+    };
+}
+
+/// Check if policy server version is compatible with  minimum kubewarden
+/// version required by the policy
+fn has_minimum_kubewarden_version(metadata: &Metadata) -> Result<()> {
+    if let Some(minimum_kubewarden_version) = &metadata.minimum_kubewarden_version {
+        let sanitized_minimum_kubewarden_version = Version {
+            major: minimum_kubewarden_version.major,
+            minor: minimum_kubewarden_version.minor,
+            // Kubewarden stack version ignore patch, prerelease and build version numbers
+            patch: 0,
+            pre: Prerelease::EMPTY,
+            build: BuildMetadata::EMPTY,
+        };
+        if *KUBEWARDEN_VERSION < sanitized_minimum_kubewarden_version {
+            return Err(anyhow!(
+                "Policy required Kubewarden version {} but is running on {}",
+                sanitized_minimum_kubewarden_version,
+                KUBEWARDEN_VERSION.to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
 
 impl PrecompiledPolicy {
     /// Load a WebAssembly module from the disk and compiles it
     fn new(engine: &wasmtime::Engine, wasm_module_path: &Path) -> Result<Self> {
         let policy_contents = fs::read(wasm_module_path)?;
         let policy_metadata = Metadata::from_contents(&policy_contents)?;
-        let execution_mode = policy_metadata.unwrap_or_default().execution_mode;
+        let metadata = policy_metadata.unwrap_or_default();
+        let execution_mode = metadata.execution_mode;
+        has_minimum_kubewarden_version(&metadata)?;
+
         let precompiled_module = engine.precompile_module(&policy_contents)?;
 
         Ok(Self {
@@ -430,5 +469,54 @@ fn verify_policy_settings(
         Ok(())
     } else {
         Err(anyhow!("{}", errors.join(", ")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    fn generate_metadata(major: u64, minor: u64, patch: u64) -> Metadata {
+        let minimum_kubewarden_version = Version {
+            major: major,
+            minor: minor,
+            patch: patch,
+            pre: Prerelease::EMPTY,
+            build: BuildMetadata::EMPTY,
+        };
+        Metadata {
+            minimum_kubewarden_version: Some(minimum_kubewarden_version),
+            ..Default::default()
+        }
+    }
+
+    #[rstest]
+    #[case(generate_metadata(KUBEWARDEN_VERSION.major -1, KUBEWARDEN_VERSION.minor, KUBEWARDEN_VERSION.patch))]
+    #[case(generate_metadata(KUBEWARDEN_VERSION.major, KUBEWARDEN_VERSION.minor - 1, KUBEWARDEN_VERSION.patch))]
+    fn recent_kubewarden_versions_test(#[case] metadata: Metadata) {
+        assert!(has_minimum_kubewarden_version(&metadata).is_ok())
+    }
+
+    #[rstest]
+    #[case(generate_metadata(KUBEWARDEN_VERSION.major +1, KUBEWARDEN_VERSION.minor, KUBEWARDEN_VERSION.patch))]
+    #[case(generate_metadata(KUBEWARDEN_VERSION.major, KUBEWARDEN_VERSION.minor + 1, KUBEWARDEN_VERSION.patch))]
+    fn old_kubewarden_versions_test(#[case] metadata: Metadata) {
+        assert!(has_minimum_kubewarden_version(&metadata).is_err())
+    }
+
+    #[test]
+    fn no_mininum_kubewarden_version_is_valid_test() {
+        let metadata = Metadata {
+            minimum_kubewarden_version: None,
+            ..Default::default()
+        };
+        assert!(has_minimum_kubewarden_version(&metadata).is_ok())
+    }
+
+    #[rstest]
+    #[case(generate_metadata(KUBEWARDEN_VERSION.major, KUBEWARDEN_VERSION.minor, KUBEWARDEN_VERSION.patch + 1))]
+    fn ignore_patch_version_test(#[case] metadata: Metadata) {
+        assert!(has_minimum_kubewarden_version(&metadata).is_ok())
     }
 }


### PR DESCRIPTION
## Description

Adds a function to check if the policy is running in a policy server with the minimum Kubewarden version required.

Fix #440

This PR depends on this [PR](https://github.com/kubewarden/policy-evaluator/pull/268) from policy-evaluator
