### PR TITLE
ci: Build also `:latest-feat-foo` images 

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+    - "feat-**"
     tags:
     - 'v*'
 

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -178,7 +178,15 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/policy-server:latest
 
       # Build and push the `:<version>` image
-      - name: Retrieve tag name
+      - name: Retrieve tag name (main branch)
+        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
+        run: |
+          echo TAG_NAME=latest >> $GITHUB_ENV
+      - name: Retrieve tag name (feat branch)
+        if: ${{ startsWith(github.ref, 'refs/heads/feat') }}
+        run: |
+          echo "TAG_NAME=latest-$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+      - name: Retrieve tag name (tag)
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           echo TAG_NAME=$(echo $GITHUB_REF | sed -e "s|refs/tags/||") >> $GITHUB_ENV


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

ci: Set image:latest tag depending on branch name, and run the workflow also on `feat-` branches.
This gives us `:latest-feat-foo` image tags.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Tested on kubewarden-controller repo.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
