### PR TITLE
wasi policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.9.5#588793547485838b82c59894faed0bec56b79943"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.10.0#650df01b300dbdc4b6f535d1697a1c650512af98"
 dependencies = [
  "base64 0.21.2",
  "chrono",
@@ -455,7 +455,7 @@ checksum = "5e5877db5d1af7fae60d06b5db9430b68056a69b3582a0be8e3691e87654aeb6"
 dependencies = [
  "async-trait",
  "async_once",
- "cached_proc_macro",
+ "cached_proc_macro 0.16.0",
  "cached_proc_macro_types",
  "futures",
  "hashbrown 0.13.2",
@@ -468,18 +468,16 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2fafddf188d13788e7099295a59b99e99b2148ab2195cae454e754cc099925"
+checksum = "b195e4fbc4b6862bbd065b991a34750399c119797efff72492f28a5864de8700"
 dependencies = [
  "async-trait",
- "async_once",
- "cached_proc_macro",
+ "cached_proc_macro 0.17.0",
  "cached_proc_macro_types",
  "futures",
  "hashbrown 0.13.2",
  "instant",
- "lazy_static",
  "once_cell",
  "thiserror",
  "tokio",
@@ -490,6 +488,19 @@ name = "cached_proc_macro"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10ca87c81aaa3a949dbbe2b5e6c2c45dbc94ba4897e45ea31ff9ec5087be3dc"
+dependencies = [
+ "cached_proc_macro_types",
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48814962d2fd604c50d2b9433c2a41a0ab567779ee2c02f7fba6eca1221f082"
 dependencies = [
  "cached_proc_macro_types",
  "darling 0.14.4",
@@ -2237,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.82.2"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7d3d52dd5c871991679102e80dfb192faaaa09fecdbccdd8c55af264ce7a8f"
+checksum = "32f468b2fa6c5ef92117813238758f79e394c2d7688bd6faa3e77243f90260b0"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2248,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.82.2"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544339f1665488243f79080441cacb09c997746fd763342303e66eebb9d3ba13"
+checksum = "337eb332d253036adc3247936248d0742c6c743f51eb38a684fd9b3b2878b27c"
 dependencies = [
  "base64 0.20.0",
  "bytes",
@@ -2284,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.82.2"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25983d07f414dfffba08c5951fe110f649113416b1d8e22f7c89c750eb2555a7"
+checksum = "f924177ad71936cfe612641b45bb9879890696d3c026f0846423529f4fa449af"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -3314,13 +3325,13 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.9.5"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.9.5#588793547485838b82c59894faed0bec56b79943"
+version = "0.10.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.10.0#650df01b300dbdc4b6f535d1697a1c650512af98"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
  "burrego",
- "cached 0.43.0",
+ "cached 0.44.0",
  "chrono",
  "dns-lookup",
  "email_address",
@@ -3346,8 +3357,12 @@ dependencies = [
  "url",
  "validator",
  "wapc",
+ "wasi-cap-std-sync",
+ "wasi-common",
  "wasmparser 0.107.0",
+ "wasmtime",
  "wasmtime-provider",
+ "wasmtime-wasi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.4.0"
 num_cpus = "1.15.0"
 opentelemetry-otlp = { version = "0.10.0", features = ["metrics", "tonic"] }
 opentelemetry = { version = "0.17", default-features = false, features = ["metrics", "trace", "rt-tokio", "serialize"] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.9.5" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.10.0" }
 rayon = "1.6"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -1,6 +1,6 @@
-*.json
-*.log
-*.prof
-*.pid
-*.out
-*.err
+/*.json
+/*.log
+/*.prof
+/*.pid
+/*.out
+/*.err

--- a/e2e-tests/01-setup.yml
+++ b/e2e-tests/01-setup.yml
@@ -28,8 +28,8 @@ testcases:
   - type: http
     method: GET
     url: http://localhost:3000/readiness
-    retry: 10
-    delay: 1
+    retry: 20
+    delay: 5
     assertions:
     - result.statuscode ShouldEqual 200
   - script: |

--- a/e2e-tests/06-wasi-policy.yml
+++ b/e2e-tests/06-wasi-policy.yml
@@ -1,0 +1,44 @@
+name: WASI policy execution
+
+testcases:
+
+- name: fixtures
+  steps:
+  - type: readfile
+    path: ./test_data/pod_creation_flux_cat.json
+    assertions:
+    - result.err ShouldBeEmpty
+    vars:
+      pod_flux_cat:
+        from: result.content
+  - type: readfile
+    path: ./test_data/pod_creation_flux_cow.json
+    assertions:
+    - result.err ShouldBeEmpty
+    vars:
+      pod_flux_cow:
+        from: result.content
+
+- name: WASI policies work as expected
+  steps:
+  - name: Send violating request
+    type: http
+    method: POST
+    url: http://localhost:3000/validate/flux
+    headers:
+      Content-Type: application/json
+    body: "{{ .fixtures.pod_flux_cat}}"
+    assertions:
+    - result.statuscode ShouldEqual 200
+    - result.bodyjson.response.allowed ShouldEqual false
+    - result.bodyjson.response.status.code ShouldNotEqual 500
+  - name: Send non violating request
+    type: http
+    method: POST
+    url: http://localhost:3000/validate/flux
+    headers:
+      Content-Type: application/json
+    body: "{{ .fixtures.pod_flux_cow }}"
+    assertions:
+    - result.statuscode ShouldEqual 200
+    - result.bodyjson.response.allowed ShouldEqual true

--- a/e2e-tests/06-wasi-policy.yml
+++ b/e2e-tests/06-wasi-policy.yml
@@ -12,16 +12,16 @@ testcases:
       pod_flux_cat:
         from: result.content
   - type: readfile
-    path: ./test_data/pod_creation_flux_cow.json
+    path: ./test_data/service-clusterip.json
     assertions:
     - result.err ShouldBeEmpty
     vars:
-      pod_flux_cow:
+      service:
         from: result.content
 
 - name: WASI policies work as expected
   steps:
-  - name: Send violating request
+  - name: Accept without mutations
     type: http
     method: POST
     url: http://localhost:3000/validate/flux
@@ -30,15 +30,20 @@ testcases:
     body: "{{ .fixtures.pod_flux_cat}}"
     assertions:
     - result.statuscode ShouldEqual 200
-    - result.bodyjson.response.allowed ShouldEqual false
+    - result.bodyjson.response.allowed ShouldEqual true
     - result.bodyjson.response.status.code ShouldNotEqual 500
-  - name: Send non violating request
+    - result.bodyjson.response ShouldNotContainKey patch
+    - result.bodyjson.response ShouldNotContainKey patchType
+  - name: Accept without mutations
     type: http
     method: POST
     url: http://localhost:3000/validate/flux
     headers:
       Content-Type: application/json
-    body: "{{ .fixtures.pod_flux_cow }}"
+    body: "{{ .fixtures.service}}"
     assertions:
     - result.statuscode ShouldEqual 200
     - result.bodyjson.response.allowed ShouldEqual true
+    - result.bodyjson.response.status.code ShouldNotEqual 500
+    - result.bodyjson.response ShouldContainKey patch
+    - result.bodyjson.response ShouldContainKey patchType

--- a/e2e-tests/test_data/pod_creation_flux_cat.json
+++ b/e2e-tests/test_data/pod_creation_flux_cat.json
@@ -1,0 +1,181 @@
+{
+  "apiVersion": "admission.k8s.io/v1",
+  "kind": "AdmissionReview",
+  "request": {
+    "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+    "kind": {
+        "group": "",
+        "version": "v1",
+        "kind": "Pod"
+    },
+    "resource": {
+        "group": "",
+        "version": "v1",
+        "resource": "pods"
+    },
+    "requestKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "Pod"
+    },
+    "requestResource": {
+        "group": "",
+        "version": "v1",
+        "resource": "pods"
+    },
+    "name": "nginx",
+    "namespace": "default",
+    "operation": "CREATE",
+    "userInfo": {
+        "username": "kubernetes-admin",
+        "groups": [
+        "system:masters",
+        "system:authenticated"
+        ]
+    },
+    "object": {
+        "kind": "Pod",
+        "apiVersion": "v1",
+        "metadata": {
+        "name": "nginx",
+        "namespace": "default",
+        "uid": "04dc7a5e-e1f1-4e34-8d65-2c9337a43e64",
+        "creationTimestamp": "2020-11-12T15:18:36Z",
+        "labels": {
+            "env": "test"
+        },
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"env\":\"test\"},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"nginx\"}],\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"example-key\",\"operator\":\"Exists\"}]}}\n",
+            "fluxcd.io/cat": "felix"
+        },
+        "managedFields": [
+            {
+            "manager": "kubectl",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2020-11-12T15:18:36Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+                "f:metadata": {
+                "f:annotations": {
+                    ".": {},
+                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                },
+                "f:labels": {
+                    ".": {},
+                    "f:env": {}
+                }
+                },
+                "f:spec": {
+                "f:containers": {
+                    "k:{\"name\":\"nginx\"}": {
+                    ".": {},
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {},
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {}
+                    }
+                },
+                "f:dnsPolicy": {},
+                "f:enableServiceLinks": {},
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {},
+                "f:terminationGracePeriodSeconds": {},
+                "f:tolerations": {}
+                }
+            }
+            }
+        ]
+        },
+        "spec": {
+        "volumes": [
+            {
+            "name": "default-token-pvpz7",
+            "secret": {
+                "secretName": "default-token-pvpz7"
+            }
+            }
+        ],
+        "containers": [
+            {
+            "name": "sleeping-sidecar",
+            "image": "alpine",
+            "command": ["sleep", "1h"],
+            "resources": {},
+            "volumeMounts": [
+                {
+                "name": "default-token-pvpz7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+            },
+            {
+            "name": "nginx",
+            "image": "nginx",
+            "resources": {},
+            "volumeMounts": [
+                {
+                "name": "default-token-pvpz7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                }
+            ],
+            "securityContext": {
+                "privileged": true
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+            }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "securityContext": {},
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+            {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+            },
+            {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+            },
+            {
+            "key": "dedicated",
+            "operator": "Equal",
+            "value": "tenantA",
+            "effect": "NoSchedule"
+            }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true,
+        "preemptionPolicy": "PreemptLowerPriority"
+        },
+        "status": {
+        "phase": "Pending",
+        "qosClass": "BestEffort"
+        }
+    },
+    "oldObject": null,
+    "dryRun": false,
+    "options": {
+        "kind": "CreateOptions",
+        "apiVersion": "meta.k8s.io/v1"
+    }
+  }
+}

--- a/e2e-tests/test_data/policies.yaml
+++ b/e2e-tests/test_data/policies.yaml
@@ -23,46 +23,9 @@ disallow-service-loadbalancer:
   allowedToMutate: false
 
 flux:
-  # TODO: change URL
-  url: file:///home/flavio/hacking/kubernetes/kubewarden/kyverno-dsl-policy/annotated-policy.wasm
+  url: ghcr.io/kubewarden/tests/go-wasi-template:v0.1.0
   policyMode: protect
-  allowedToMutate: false
+  allowedToMutate: true
   settings:
-    policy: |
-      apiVersion: kyverno.io/v1
-      kind: ClusterPolicy
-      metadata:
-        name: allowed-annotations
-        annotations:
-          policies.kyverno.io/title: Allowed Annotations
-          policies.kyverno.io/category: Other
-          policies.kyverno.io/severity: medium
-          kyverno.io/kyverno-version: 1.6.0
-          policies.kyverno.io/minversion: 1.6.0
-          kyverno.io/kubernetes-version: "1.23"
-          policies.kyverno.io/subject: Pod, Annotation
-          policies.kyverno.io/description: >-
-            Rather than creating a deny list of annotations, it may be more useful
-            to invert that list and create an allow list which then denies any others.
-            This policy demonstrates how to allow two annotations with a specific key
-            name of fluxcd.io/ while denying others that do not meet the pattern.      
-      spec:
-        validationFailureAction: audit
-        background: true
-        rules:
-        - name: allowed-fluxcd-annotations
-          match:
-            any:
-            - resources:
-                kinds:
-                  - Pod
-          validate:
-            message: The only approved FluxCD annotations are `fluxcd.io/cow` and `fluxcd.io/dog`.
-            deny:
-              conditions:
-                all:
-                - key: "{{ request.object.metadata.annotations.keys(@)[?contains(@, 'fluxcd.io/')] }}"
-                  operator: AnyNotIn
-                  value:
-                  - fluxcd.io/cow
-                  - fluxcd.io/dog
+    requiredAnnotations:
+      "fluxcd.io/cat": "felix"

--- a/e2e-tests/test_data/policies.yaml
+++ b/e2e-tests/test_data/policies.yaml
@@ -21,3 +21,48 @@ disallow-service-loadbalancer:
   url: ghcr.io/kubewarden/tests/disallow-service-loadbalancer:v0.1.5
   policyMode: protect
   allowedToMutate: false
+
+flux:
+  # TODO: change URL
+  url: file:///home/flavio/hacking/kubernetes/kubewarden/kyverno-dsl-policy/annotated-policy.wasm
+  policyMode: protect
+  allowedToMutate: false
+  settings:
+    policy: |
+      apiVersion: kyverno.io/v1
+      kind: ClusterPolicy
+      metadata:
+        name: allowed-annotations
+        annotations:
+          policies.kyverno.io/title: Allowed Annotations
+          policies.kyverno.io/category: Other
+          policies.kyverno.io/severity: medium
+          kyverno.io/kyverno-version: 1.6.0
+          policies.kyverno.io/minversion: 1.6.0
+          kyverno.io/kubernetes-version: "1.23"
+          policies.kyverno.io/subject: Pod, Annotation
+          policies.kyverno.io/description: >-
+            Rather than creating a deny list of annotations, it may be more useful
+            to invert that list and create an allow list which then denies any others.
+            This policy demonstrates how to allow two annotations with a specific key
+            name of fluxcd.io/ while denying others that do not meet the pattern.      
+      spec:
+        validationFailureAction: audit
+        background: true
+        rules:
+        - name: allowed-fluxcd-annotations
+          match:
+            any:
+            - resources:
+                kinds:
+                  - Pod
+          validate:
+            message: The only approved FluxCD annotations are `fluxcd.io/cow` and `fluxcd.io/dog`.
+            deny:
+              conditions:
+                all:
+                - key: "{{ request.object.metadata.annotations.keys(@)[?contains(@, 'fluxcd.io/')] }}"
+                  operator: AnyNotIn
+                  value:
+                  - fluxcd.io/cow
+                  - fluxcd.io/dog


### PR DESCRIPTION
Support policies that implement the new WASI protocol.

This policy execution mode is not the best one, but it allows the execution of WASM modules that do not leverage waPC. This is the case of modules built by the official Go compile.
