### PR TITLE
fix: properly auto label dependencies fixes.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,14 +34,16 @@ autolabeler:
     title: '/.*!:.*/'
   - label: 'area/dependencies'
     title: 'chore(deps)'
+  - label: 'area/dependencies'
+    title: 'fix(deps)'
+  - label: 'area/dependencies'
+    title: 'build(deps)'
   - label: 'kind/feature'
     title: 'feat'
   - label: 'kind/bug'
     title: 'fix'
   - label: 'kind/chore'
     title: 'chore'
-  - label: 'area/dependencies'
-    title: 'build(deps)'
 
 version-resolver:
   major:


### PR DESCRIPTION
## Description

Updates the release drafter configuration file to properly label renovate bot PR starting with "fix(deps)" as area/dependencies. Therefore, the PR will land in the "Maintenance" change log section.

