### PR TITLE
fix: publish release drafter draft release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,40 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+
+      - name: Get old release tag
+        id: get_old_release_tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let release = await github.rest.repos.getLatestRelease({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+            });
+
+            if (release.status  === 200 ) {
+              core.setOutput('release_tag', release.data.tag_name)
+              return
+            }
+            core.setFailed("Cannot find latest release")
+
+      - name: Get release ID from the release created by release drafter
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let releases = await github.rest.repos.listReleases({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+            });
+            for (const release of releases.data) {
+              if (release.draft) {
+                      core.info(release)
+                      core.exportVariable('RELEASE_ID', release.id)
+                      return
+              }
+            }
+            core.setFailed(`Draft release not found`)
+
       - name: Download build artifacts
         uses: actions/github-script@v6
         with:
@@ -38,36 +72,48 @@ jobs:
               file_path = `${process.env.GITHUB_WORKSPACE}/${artifact.name}.zip`;
               fs.writeFileSync(file_path, Buffer.from(download.data));
             }
+
       - name: 'Unzip build artifacts'
         run: unzip -n "policy-server-*.zip" -d artifacts
 
-      - name: Get old release tag
-        id: get_old_release_tag
+      - name: Upload release assets
+        id: upload_release_assets
         uses: actions/github-script@v6
         with:
           script: |
-            let release = await github.rest.repos.getLatestRelease({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-            });
+            let fs = require('fs');
+            // The artifact directory is defined in the previous step. When the
+            // zip files are expanded.
+            let files = fs.readdirSync("artifacts")
+            // Envvar exported in the step para the draft release is found
+            const {RELEASE_ID} = process.env
 
-            if (release.status  === 200 ) {
-              core.setOutput('release_tag', release.data.tag_name)
-              return
+            for (const file of files) {
+              let file_data = fs.readFileSync(`artifacts/${file}`);
+
+              let response = await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: `${RELEASE_ID}`,
+                name: file,
+                data: file_data,
+              });
             }
-            core.setFailed("Cannot find latest release")
 
-      - name: Create release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish release
+        uses: actions/github-script@v6
         with:
-          tag_name: ${{ github.event.workflow_run.head_branch }}
-          name: Release policy-server ${{ github.event.workflow_run.head_branch }}
-          draft: false
-          prerelease: ${{ contains(github.event.workflow_run.head_branch, '-alpha') || contains(github.event.workflow_run.head_branch, '-beta') || contains(github.event.workflow_run.head_branch, '-rc') }}
-          files: |
-            artifacts/*
+          script: |
+            const {RELEASE_ID} = process.env
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: `${RELEASE_ID}`,
+              draft: false,
+              tag_name: `${{ github.event.workflow_run.head_branch }}`,
+              name: `${{ github.event.workflow_run.head_branch }}`,
+              prerelease: `${{ contains(github.event.workflow_run.head_branch, '-alpha') || contains(github.event.workflow_run.head_branch, '-beta') || contains(github.event.workflow_run.head_branch, '-rc') }}`,
+            });
 
       - name: Get new release tag
         id: get_new_release_tag


### PR DESCRIPTION
## Description

Updates the release CI to publish the draft release created by release drafter instead of creating a new release. Therefore, we will use the nice changelog.

Fix #435 
