### PR TITLE
Bump v1.7.0-rc1 version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "1.6.0"
+version = "1.7.0-rc1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-server"
-version = "1.6.0"
+version = "1.7.0-rc1"
 authors = [
   "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",


### PR DESCRIPTION
## Description

Updates the Cargo.toml and Cargo.lock files bumping the policy-server version to v1.7.0-rc1.

Related to https://github.com/kubewarden/kubewarden-controller/issues/473