### PR TITLE
fix: missing label in the changelog feature section.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,6 +6,7 @@ categories:
   - title: '🚀 Features'
     labels:
       - 'kind/enhancement'
+      - 'kind/feature'
   - title: '🐛 Bug Fixes'
     labels:
       - 'kind/bug'


### PR DESCRIPTION
## Description

Updates the release drafter configuration file to show PR tagged with kind/feature in the feature section in the changelog.
