### PR TITLE
fix(perf): reduce memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,6 +1552,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
 
 [[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2008,15 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -2456,6 +2475,12 @@ name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3480,6 +3505,7 @@ dependencies = [
  "anyhow",
  "clap",
  "daemonize",
+ "humansize",
  "itertools 0.11.0",
  "k8s-openapi",
  "lazy_static",
@@ -3487,6 +3513,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "policy-evaluator",
+ "procfs",
  "rayon",
  "rstest",
  "semver",
@@ -3575,6 +3602,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "rustix 0.36.15",
 ]
 
 [[package]]
@@ -4039,6 +4081,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37f1bd5ef1b5422177b7646cba67430579cfe2ace80f284fee876bca52ad941"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes 1.0.11",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ edition = "2021"
 anyhow = "1.0"
 clap = { version = "4.2", features = [ "cargo", "env" ] }
 daemonize = "0.5"
+humansize = "2.1"
 itertools = "0.11.0"
 k8s-openapi = { version = "0.18.0", default-features = false, features = ["v1_26"] }
 lazy_static = "1.4.0"
 num_cpus = "1.16.0"
 opentelemetry-otlp = { version = "0.10.0", features = ["metrics", "tonic"] }
 opentelemetry = { version = "0.17", default-features = false, features = ["metrics", "trace", "rt-tokio", "serialize"] }
+procfs = "0.15"
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.11.0" }
 rayon = "1.6"
 serde_json = "1.0"


### PR DESCRIPTION
Reduce the amount of memory being used by policy-server at runtime.

This table contains a comparison of the memory usage (Mb) before and after this optimization:

| Workers (#) | Vanilla (Mb) | Optimized (Mb) | Improvement (%) |
|-------------|--------------|----------------|-----------------|
| 1           | 634.356      | 506.484        | -20.16          |
| 2           | 790.672      | 598.902        | -24.25          |
| 3           | 954.726      | 680.124        | -28.76          |
| 4           | 1108.042     | 774.498        | -30.10          |

![comparison](https://github.com/kubewarden/policy-server/assets/22728/fab3eba8-d604-4c7f-b0a5-9cc4189a1c64)
