### PR TITLE
chore: bump otel collector dev container to 0.85.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 bom-cargo.json
 /bin
+/registry

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: jaegertracing/all-in-one:latest
     ports:
       - "16686:16686"
-      - "14250:14250"
+      - "4318:4317"
   otel-collector:
-    image: otel/opentelemetry-collector:0.84.0
+    image: otel/opentelemetry-collector:0.85.0
     volumes:
       - ./otel-collector-minimal-config.yml:/etc/otel-collector-config.yml
     ports:

--- a/hack/otel-collector-minimal-config.yml
+++ b/hack/otel-collector-minimal-config.yml
@@ -2,12 +2,6 @@
 # that collects traces via the otlp protocol, and then sends them via
 # batches to a central jaeger collector
 #
-# A simple otel-collector instance can be started in this way:
-#
-#   docker run --rm -p 4317:4317 \
-#     -v `pwd`/otel-collector-minimal-config.yaml:/etc/otel/config.yaml:ro \
-#     otel/opentelemetry-collector-dev:latest
-#
 
 receivers:
   otlp:
@@ -18,8 +12,8 @@ processors:
   batch:
 
 exporters:
-  jaeger:
-    endpoint: "jaeger:14250"
+  otlp/jaeger:
+    endpoint: "jaeger:4317"
     tls:
       insecure: true
   prometheus:
@@ -34,4 +28,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [jaeger]
+      exporters: [otlp/jaeger]


### PR DESCRIPTION
## Description
Bumps opentelemetry collector dev container to 0.85.0, and switches to OTLP exporter for Jaeger.

## Test
following the DEVELOPMENT.md guide is working (aka metrics and traces are collected correctly)

## Additional Information

Related to: https://github.com/kubewarden/helm-charts/pull/317
