### PR TITLE
feat: Add new `request_origin` to metrics baggage

### DIFF
--- a/src/communication.rs
+++ b/src/communication.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use core::fmt;
 use policy_evaluator::admission_response::AdmissionResponse;
 use policy_evaluator::policy_evaluator::ValidateRequest;
 use std::collections::HashMap;
@@ -11,6 +12,15 @@ use crate::settings::Policy;
 pub(crate) enum RequestOrigin {
     Validate,
     Audit,
+}
+
+impl fmt::Display for RequestOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RequestOrigin::Validate => write!(f, "validate"),
+            RequestOrigin::Audit => write!(f, "audit"),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -32,6 +32,7 @@ pub struct PolicyEvaluation {
     pub(crate) resource_request_operation: String,
     pub(crate) accepted: bool,
     pub(crate) mutated: bool,
+    pub(crate) request_origin: String,
     pub(crate) error_code: Option<u16>,
 }
 
@@ -50,6 +51,7 @@ impl Into<Vec<KeyValue>> for &PolicyEvaluation {
             ),
             KeyValue::new("accepted", self.accepted),
             KeyValue::new("mutated", self.mutated),
+            KeyValue::new("request_origin", self.request_origin.clone()),
         ];
         if let Some(resource_namespace) = &self.resource_namespace {
             baggage.append(&mut vec![KeyValue::new(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -227,6 +227,7 @@ impl Worker {
                     resource_request_operation: adm_req.clone().operation,
                     accepted,
                     mutated,
+                    request_origin: req.request_origin.to_string(),
                     error_code,
                 };
                 metrics::record_policy_latency(policy_evaluation_duration, &policy_evaluation);


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/policy-server/issues/597

This new `request_origin` field informs if the policy request was a `validate` one (going through the k8s apiserver) or an `audit` one (synthetic evaluation requests generated by the audit scanner).


## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested successfully with `docker compose`, by adding a new grafana visualization such as
 `sum(kubewarden_policy_evaluations_total{request_origin="validate"})`.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
