### PR TITLE
chore: bump version to v1.11.0-rc2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-server"
-version = "1.11.0-rc1"
+version = "1.11.0-rc2"
 authors = [
   "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",


### PR DESCRIPTION
## Description

Prepare for `v1.11.0-rc2` release
