### PR TITLE
feat: do not exit on policy error

### DIFF
--- a/src/evaluation/errors.rs
+++ b/src/evaluation/errors.rs
@@ -4,6 +4,9 @@ pub type Result<T> = std::result::Result<T, EvaluationError>;
 
 #[derive(Debug, Error)]
 pub enum EvaluationError {
+    #[error("{0}")]
+    PolicyInitialization(String),
+
     #[error("unknown policy: {0}")]
     PolicyNotFound(String),
 

--- a/src/evaluation/evaluation_environment.rs
+++ b/src/evaluation/evaluation_environment.rs
@@ -438,7 +438,7 @@ mod tests {
         let validate_request =
             ValidateRequest::AdmissionRequest(build_admission_review_request().request);
         assert!(matches!(
-            evaluation_environment.validate(policy_id, &validate_request).err().unwrap(),
+            evaluation_environment.validate(policy_id, &validate_request).unwrap_err(),
             EvaluationError::PolicyInitialization(error) if error == "error"
         ));
     }

--- a/src/evaluation/evaluation_environment.rs
+++ b/src/evaluation/evaluation_environment.rs
@@ -61,6 +61,11 @@ pub(crate) struct EvaluationEnvironment {
     /// Map a `policy_id` to the `PolicyEvaluationSettings` instance. This allows us to obtain
     /// the list of settings to be used when evaluating a given policy.
     policy_id_to_settings: HashMap<String, PolicyEvaluationSettings>,
+
+    /// A map with the policy ID as key, and the error message as value.
+    /// This is used to store the errors that occurred during policies initialization.
+    /// The errors can occur in the fetching of the policy, or in the validation of the settings.
+    policy_initialization_errors: HashMap<String, String>,
 }
 
 #[cfg_attr(test, automock)]
@@ -88,6 +93,16 @@ impl EvaluationEnvironment {
                 ))
             })?;
 
+            let precompiled_policy = match precompiled_policy.as_ref() {
+                Ok(precompiled_policy) => precompiled_policy,
+                Err(e) => {
+                    eval_env
+                        .policy_initialization_errors
+                        .insert(policy_id.clone(), e.to_string());
+                    continue;
+                }
+            };
+
             eval_env
                 .register(
                     engine,
@@ -98,6 +113,8 @@ impl EvaluationEnvironment {
                     policy_evaluation_limit_seconds,
                 )
                 .map_err(|e| EvaluationError::BootstrapFailure(e.to_string()))?;
+
+            eval_env.validate_settings(policy_id)?;
         }
 
         Ok(eval_env)
@@ -208,6 +225,10 @@ impl EvaluationEnvironment {
 
     /// Perform a request validation
     pub fn validate(&self, policy_id: &str, req: &ValidateRequest) -> Result<AdmissionResponse> {
+        if let Some(error) = self.policy_initialization_errors.get(policy_id) {
+            return Err(EvaluationError::PolicyInitialization(error.to_string()));
+        }
+
         let settings = self.get_policy_settings(policy_id)?;
         let mut evaluator = self.rehydrate(policy_id)?;
 
@@ -215,11 +236,30 @@ impl EvaluationEnvironment {
     }
 
     /// Validate the settings the user provided for the given policy
-    pub fn validate_settings(&self, policy_id: &str) -> Result<SettingsValidationResponse> {
+    fn validate_settings(&mut self, policy_id: &str) -> Result<()> {
         let settings = self.get_policy_settings(policy_id)?;
         let mut evaluator = self.rehydrate(policy_id)?;
 
-        Ok(evaluator.validate_settings(&settings.settings))
+        match evaluator.validate_settings(&settings.settings) {
+            SettingsValidationResponse {
+                valid: true,
+                message: _,
+            } => return Ok(()),
+            SettingsValidationResponse {
+                valid: false,
+                message,
+            } => {
+                self.policy_initialization_errors.insert(
+                    policy_id.to_string(),
+                    format!(
+                        "Policy settings are invalid: {}",
+                        message.unwrap_or("no message".to_owned())
+                    ),
+                );
+            }
+        };
+
+        Ok(())
     }
 
     /// Internal method, create a `PolicyEvaluator` by using a pre-initialized instance
@@ -321,7 +361,7 @@ mod tests {
                     context_aware_resources: BTreeSet::new(),
                 },
             );
-            precompiled_policies.insert(policy_url, precompiled_policy.clone());
+            precompiled_policies.insert(policy_url, Ok(precompiled_policy.clone()));
         }
 
         EvaluationEnvironment::new(
@@ -385,5 +425,21 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[test]
+    fn validate_policy_with_initialization_error() {
+        let mut evaluation_environment = build_evaluation_environment().unwrap();
+        let policy_id = "policy_3";
+        evaluation_environment
+            .policy_initialization_errors
+            .insert(policy_id.to_string(), "error".to_string());
+
+        let validate_request =
+            ValidateRequest::AdmissionRequest(build_admission_review_request().request);
+        assert!(matches!(
+            evaluation_environment.validate(policy_id, &validate_request).err().unwrap(),
+            EvaluationError::PolicyInitialization(error) if error == "error"
+        ));
     }
 }

--- a/src/evaluation/precompiled_policy.rs
+++ b/src/evaluation/precompiled_policy.rs
@@ -66,8 +66,9 @@ impl PrecompiledPolicy {
 
 /// A dictionary with:
 /// * Key: the URL of the WebAssembly module
-/// * value: the PrecompiledPolicy
-pub(crate) type PrecompiledPolicies = HashMap<String, PrecompiledPolicy>;
+/// * Value: a Result containing the precompiled policy or an error.
+/// Errors are stored and will be reported to the user in the API response.
+pub(crate) type PrecompiledPolicies = HashMap<String, Result<PrecompiledPolicy>>;
 
 /// Check if policy server version is compatible with  minimum kubewarden
 /// version required by the policy

--- a/src/policy_downloader.rs
+++ b/src/policy_downloader.rs
@@ -293,7 +293,7 @@ mod tests {
     }
 
     #[test]
-    fn download_and_verify_success() {
+    fn verify_success() {
         let verification_cfg_yml = r#"---
     allOf:
       - kind: pubKey
@@ -363,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    fn download_and_verify_error() {
+    fn verify_error() {
         let verification_cfg_yml = r#"---
     allOf:
       - kind: githubAction
@@ -407,9 +407,11 @@ mod tests {
         // be downloaded
         assert_eq!(fetched_policies.len(), 1);
 
-        assert!(fetched_policies
-            .get("registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9")
-            .unwrap()
-            .is_err());
+        assert!(matches!(
+            fetched_policies
+                .get("registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9")
+                .unwrap(),
+            Err(error) if error.to_string().contains("Policy 'pod-privileged' cannot be verified: Image verification failed: missing signatures")
+        ));
     }
 }

--- a/src/policy_downloader.rs
+++ b/src/policy_downloader.rs
@@ -162,24 +162,6 @@ impl Downloader {
             };
 
             if let Some(ver) = self.verifier.as_mut() {
-                if verified_manifest_digest.is_none() {
-                    // when deserializing keys we check that have keys to
-                    // verify. We will always have a digest manifest
-                    error!(
-                        policy = name.as_str(),
-                        "cannot verify policy, missing verified manifest digest"
-                    );
-                    fetched_policies.insert(
-                        policy.url.clone(),
-                        Err(anyhow!(
-                            "Policy {} cannot be verified, missing verified manifest digest",
-                            name
-                        )),
-                    );
-
-                    continue;
-                }
-
                 if let Err(e) = ver
                     .verify_local_file_checksum(
                         &fetched_policy,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -47,6 +47,29 @@ pub(crate) async fn app() -> Router {
                 context_aware_resources: BTreeSet::new(),
             },
         ),
+        (
+            "invalid_settings".to_owned(),
+            Policy {
+                url: "ghcr.io/kubewarden/tests/sleeping-policy:v0.1.0".to_owned(),
+                policy_mode: PolicyMode::Protect,
+                allowed_to_mutate: None,
+                settings: Some(HashMap::from([(
+                    "sleepMilliseconds".to_owned(),
+                    "abc".into(),
+                )])),
+                context_aware_resources: BTreeSet::new(),
+            },
+        ),
+        (
+            "wrong_url".to_owned(),
+            Policy {
+                url: "ghcr.io/kubewarden/tests/not_existing:v0.1.0".to_owned(),
+                policy_mode: PolicyMode::Protect,
+                allowed_to_mutate: None,
+                settings: None,
+                context_aware_resources: BTreeSet::new(),
+            },
+        ),
     ]);
 
     let config = Config {


### PR DESCRIPTION
## Description

Fix: #682

The policy server was exiting with an error If a policy could not be downloaded, verified, or had invalid settings, causing the Pod to restart. The policy server pod entered a crash back-off loop in the worst-case scenario. 
This PR changes the way the policy server manages policy initialization errors by not exiting and storing the error in the evaluation environment so it can be bubbled up to the API in the form of a rejected `AdmissionResponse` with the error as message and the status code set to `500`.
