### PR TITLE
fix: add hidden flag/env to toggle continuing on initialization errors

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -165,6 +165,11 @@ pub(crate) fn build_cli() -> Command {
                 .env("KUBEWARDEN_ENABLE_PPROF")
                 .action(ArgAction::SetTrue)
                 .help("Enable pprof profiling"),
+            Arg::new("continue-on-errors")
+                .long("continue-on-errors")
+                .env("KUBEWARDEN_CONTINUE_ON_ERRORS")
+                .action(ArgAction::SetTrue)
+                .hide(true)
     ];
     args.sort_by(|a, b| a.get_id().cmp(b.get_id()));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub struct Config {
     pub daemon_pid_file: String,
     pub daemon_stdout_file: Option<String>,
     pub daemon_stderr_file: Option<String>,
+    pub continue_on_errors: bool,
 }
 
 pub struct TlsConfig {
@@ -137,6 +138,11 @@ impl Config {
             .expect("clap should have assigned a default value")
             .to_owned();
 
+        let continue_on_errors = matches
+            .get_one::<bool>("continue-on-errors")
+            .expect("clap should have assigned a default value")
+            .to_owned();
+
         Ok(Self {
             addr,
             sources,
@@ -158,6 +164,7 @@ impl Config {
             daemon_stdout_file,
             daemon_stderr_file,
             enable_pprof,
+            continue_on_errors,
         })
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -93,6 +93,7 @@ pub(crate) async fn app() -> Router {
         daemon_stdout_file: None,
         daemon_stderr_file: None,
         enable_pprof: true,
+        continue_on_errors: true,
     };
 
     let server = PolicyServer::new_from_config(config).await.unwrap();


### PR DESCRIPTION
## Description

Adds a flag to toggle the "continue on errors" behavior, so we can keep working on the policy server error handling flow without breaking the current user experience.

Fixes: #730 
