### PR TITLE
feat: switch to jemalloc allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,6 +3551,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tower",
  "tower-http",
@@ -4848,6 +4849,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ mockall_double = "0.3"
 axum = { version = "0.7.5", features = ["macros", "query"] }
 axum-server = { version = "0.6", features = ["tls-rustls"] }
 tower-http = { version = "0.5.2", features = ["trace"] }
+tikv-jemallocator = { version = "0.5.4", features = [
+  "unprefixed_malloc_on_supported_platforms",
+] }
 
 [dev-dependencies]
 mockall = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,15 @@ use policy_server::metrics::setup_metrics;
 use policy_server::tracing::setup_tracing;
 use policy_server::PolicyServer;
 
+use tikv_jemallocator::Jemalloc;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+#[allow(non_upper_case_globals)]
+#[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"background_thread:true,tcache_max:4096,dirty_decay_ms:5000,muzzy_decay_ms:5000,abort_conf:true\0";
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let matches = cli::build_cli().get_matches();


### PR DESCRIPTION
## Description

Switch to jemalloc, fixes #763.

The allocator is configured to prioritize memory usage, see: https://github.com/jemalloc/jemalloc/blob/dev/TUNING.md

Also, the  `unprefixed_malloc_on_supported_platforms` feature was enabled, see https://github.com/tikv/jemallocator/blob/master/jemalloc-sys/README.md#features
