### PR TITLE
fix: configure jemalloc in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,17 @@ use crate::evaluation::{
 use crate::policy_downloader::{Downloader, FetchedPolicies};
 use config::Config;
 
+use tikv_jemallocator::Jemalloc;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+#[allow(non_upper_case_globals)]
+#[export_name = "malloc_conf"]
+/// Prioritize memory usage, then enable features request by pprof but do not activate them by
+/// default. When pprof is activate there's a CPU overhead.
+pub static malloc_conf: &[u8] = b"background_thread:true,tcache_max:4096,dirty_decay_ms:5000,muzzy_decay_ms:5000,abort_conf:true,prof:true,prof_active:false,lg_prof_sample:19\0";
+
 pub struct PolicyServer {
     router: Router,
     callback_handler: CallbackHandler,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,17 +10,6 @@ use policy_server::metrics::setup_metrics;
 use policy_server::tracing::setup_tracing;
 use policy_server::PolicyServer;
 
-use tikv_jemallocator::Jemalloc;
-
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
-
-#[allow(non_upper_case_globals)]
-#[export_name = "malloc_conf"]
-/// Prioritize memory usage, then enable features request by pprof but do not activate them by
-/// default. When pprof is activate there's a CPU overhead.
-pub static malloc_conf: &[u8] = b"background_thread:true,tcache_max:4096,dirty_decay_ms:5000,muzzy_decay_ms:5000,abort_conf:true,prof:true,prof_active:false,lg_prof_sample:19\0";
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let matches = cli::build_cli().get_matches();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -69,7 +69,7 @@ pub(crate) fn default_test_config() -> Config {
         daemon_pid_file: "policy_server.pid".to_owned(),
         daemon_stdout_file: None,
         daemon_stderr_file: None,
-        enable_pprof: true,
+        enable_pprof: false,
         continue_on_errors: false,
     }
 }


### PR DESCRIPTION
## Description

Integration tests were failing since we were activating the profiling, but there jemalloc was not configured in `lib.rs` (integration tests instantiate a policy server using the library part of the crate).

Also, we don't need to enable pprof when testing, since it could slow down the CI.