### PR TITLE
chore: prepare to release 1.13.0 rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.17.2#e505f91e2cfc09a133e15f5988debd8150909751"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.17.4#703b87c00cb195cb0bac6ee7e65b39efcb6aa7ac"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2455,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "kube"
 version = "0.91.0"
-source = "git+https://github.com/fabriziosestito/kube?rev=f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8#f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8"
+source = "git+https://github.com/fabriziosestito/kube?branch=fix/reduce-buffering-between-watcher-and-store#d573f4f78cbb015551b9480817506e23b88b9af0"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "kube-client"
 version = "0.91.0"
-source = "git+https://github.com/fabriziosestito/kube?rev=f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8#f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8"
+source = "git+https://github.com/fabriziosestito/kube?branch=fix/reduce-buffering-between-watcher-and-store#d573f4f78cbb015551b9480817506e23b88b9af0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2502,7 +2502,7 @@ dependencies = [
 [[package]]
 name = "kube-core"
 version = "0.91.0"
-source = "git+https://github.com/fabriziosestito/kube?rev=f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8#f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8"
+source = "git+https://github.com/fabriziosestito/kube?branch=fix/reduce-buffering-between-watcher-and-store#d573f4f78cbb015551b9480817506e23b88b9af0"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2517,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "kube-runtime"
 version = "0.91.0"
-source = "git+https://github.com/fabriziosestito/kube?rev=f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8#f7de17b6984839c08c9a0645d0ec73c2ffd6f4a8"
+source = "git+https://github.com/fabriziosestito/kube?branch=fix/reduce-buffering-between-watcher-and-store#d573f4f78cbb015551b9480817506e23b88b9af0"
 dependencies = [
  "ahash 0.8.11",
  "async-broadcast",
@@ -3607,8 +3607,8 @@ checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.17.2"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.17.2#e505f91e2cfc09a133e15f5988debd8150909751"
+version = "0.17.4"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.17.4#703b87c00cb195cb0bac6ee7e65b39efcb6aa7ac"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "1.12.0"
+version = "1.13.0-rc1"
 dependencies = [
  "anyhow",
  "axum 0.7.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-server"
-version = "1.12.0"
+version = "1.13.0-rc1"
 authors = [
   "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ opentelemetry = { version = "0.22.0", default-features = false, features = [
 ] }
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
 pprof = { version = "0.13", features = ["prost-codec"] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.17.2" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.17.4" }
 rustls-pki-types = { version = "1", features = ["alloc"] }
 rayon = "1.10"
 regex = "1.10"


### PR DESCRIPTION
## Description

bump policy-evaluator to v0.17.4

bump Cargo.toml to v1.13.0-rc1
