### PR TITLE
sigstore fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70 AS build
+FROM rust:1.78 AS build
 WORKDIR /usr/src
 
 # Download the target for static linking.


### PR DESCRIPTION
Ensure sigstore Trust Root is always fetched. We must always fetch the Sigstore Trust Root, otherwise policies making use of Sigstore won't be able to do keyless verifications.

Prior to this commit, the Trust Root was fetched only when the policy integrity verification was turned on.
