### PR TITLE
chore: bump version to v1.14.0-rc1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,7 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.17.7#cd093d73ebd17ad5390ef94e70940bc79daae798"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.0#2b2f7a8a4637071d03c40ea92c358ddfd1121167"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3722,8 +3722,8 @@ checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.17.7"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.17.7#cd093d73ebd17ad5390ef94e70940bc79daae798"
+version = "0.18.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.0#2b2f7a8a4637071d03c40ea92c358ddfd1121167"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3755,7 +3755,7 @@ dependencies = [
  "validator",
  "wapc",
  "wasi-common",
- "wasmparser 0.210.0",
+ "wasmparser 0.211.1",
  "wasmtime",
  "wasmtime-provider",
  "wasmtime-wasi",
@@ -5970,9 +5970,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.210.0"
+version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bbcd21e7581619d9f6ca00f8c4f08f1cacfe58bf63f83af57cd0476f1026f5"
+checksum = "3189cc8a91f547390e2f043ca3b3e3fe0892f7d581767fd4e4b7f3dc3fe8e561"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "1.13.1"
+version = "1.14.0-rc1"
 dependencies = [
  "anyhow",
  "axum 0.7.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ opentelemetry = { version = "0.22.0", default-features = false, features = [
 ] }
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
 pprof = { version = "0.13", features = ["prost-codec"] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.17.7" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.0" }
 rustls-pki-types = { version = "1", features = ["alloc"] }
 rayon = "1.10"
 regex = "1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-server"
-version = "1.13.1"
+version = "1.14.0-rc1"
 authors = [
   "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",


### PR DESCRIPTION
## Description

Bumps the policy-server version in the Cargo files to v1.14.0-rc1. It also updates the policy-evaluator version.
