### PR TITLE
chore: bump version to v1.14.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "1.14.0-rc1"
+version = "1.14.0-rc2"
 dependencies = [
  "anyhow",
  "axum 0.7.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "policy-server"
-version = "1.14.0-rc1"
+version = "1.14.0-rc2"
 authors = [
   "Kubewarden Developers <kubewarden@suse.de>",
   "Flavio Castelli <fcastelli@suse.com>",


### PR DESCRIPTION
## Description

Bumps the policy-server version in the Cargo files to v1.14.0-rc2.


