### PR TITLE
deps: Bump opentelemetry dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,15 +936,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,9 +3095,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3114,21 +3105,19 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
 dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost 0.12.6",
  "thiserror",
@@ -3138,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3149,23 +3138,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
-
-[[package]]
 name = "opentelemetry_sdk"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
+ "lazy_static",
  "once_cell",
  "opentelemetry",
  "ordered-float 4.2.1",
@@ -5432,9 +5415,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -5578,12 +5561,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-decode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ opentelemetry = { version = "0.23.0", default-features = false, features = [
   "metrics",
   "trace",
 ] }
-opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio"] }
 pprof = { version = "0.13", features = ["prost-codec"] }
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.0" }
 rustls-pki-types = { version = "1", features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = "1.4.0"
 mime = "0.3"
 num_cpus = "1.16.0"
 opentelemetry-otlp = { version = "0.15.0", features = ["metrics", "tonic"] }
-opentelemetry = { version = "0.22.0", default-features = false, features = [
+opentelemetry = { version = "0.23.0", default-features = false, features = [
   "metrics",
   "trace",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ sha2 = "0.10"
 thiserror = "1.0"
 tokio = { version = "^1.38.0", features = ["full"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.23.0"
+tracing-opentelemetry = "0.24.0"
 tracing-subscriber = { version = "0.3", features = ["ansi", "fmt", "json"] }
 semver = { version = "1.0.22", features = ["serde"] }
 mockall_double = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ k8s-openapi = { version = "0.22.0", default-features = false, features = [
 lazy_static = "1.4.0"
 mime = "0.3"
 num_cpus = "1.16.0"
-opentelemetry-otlp = { version = "0.15.0", features = ["metrics", "tonic"] }
+opentelemetry-otlp = { version = "0.16.0", features = ["metrics", "tonic"] }
 opentelemetry = { version = "0.23.0", default-features = false, features = [
   "metrics",
   "trace",

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "16686:16686"
       - "4318:4317"
   otel-collector:
-    image: otel/opentelemetry-collector:0.85.0
+    image: otel/opentelemetry-collector:0.98.0
     volumes:
       - ./otel-collector-minimal-config.yml:/etc/otel-collector-config.yml
     ports:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
- CI.
- Performing docker-compose local deployment and testing: Tracing is broken, as jaeger fails to connect with otel-collector. This is because we aren't pinning jaeger.
- end-to-end tests: broken for latest jaeger-operator-2.54.0. Working for jaeger-operator-2.49.0, the one we list as supported in https://docs.kubewarden.io/reference/dependency-matrix.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
