### PR TITLE
fix policies yml parsing

### DIFF
--- a/policies.yml.example
+++ b/policies.yml.example
@@ -8,7 +8,7 @@ psp-capabilities:
     required_drop_capabilities: ["KILL"]
 pod-image-signatures: # policy group
   policies:
-    - name: sigstore_pgp
+    sigstore_pgp:
       url: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
       settings:
         signatures:
@@ -16,14 +16,14 @@ pod-image-signatures: # policy group
             pubKeys:
               - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
               - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
-    - name: sigstore_gh_action
+    sigstore_gh_action:
       url: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
       settings:
         signatures:
           - image: "*"
             githubActions:
             owner: "kubewarden"
-    - name: reject_latest_tag
+    reject_latest_tag:
       url: ghcr.io/kubewarden/policies/trusted-repos-policy:v0.1.12
       settings:
         tags:

--- a/src/config.rs
+++ b/src/config.rs
@@ -333,7 +333,7 @@ impl PolicyGroupMember {
 
 /// Describes a policy that can be either an individual policy or a group policy.
 #[derive(Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields, untagged, rename_all = "camelCase")]
+#[serde(untagged, rename_all = "camelCase")]
 pub enum PolicyOrPolicyGroup {
     /// An individual policy
     Policy {


### PR DESCRIPTION
Address the failures reported by our CI system.

They were caused by two changes done to the `policies.yml` file parsing:

- The usage of `deny_unknown_fields` with untagged `Enum` is affected by a bug inside of the `serde` library. This is a known issue
- The `policies.yml.example` file had invalid contents
