### PR TITLE
fix: policies.yml parsing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -258,7 +258,7 @@ fn remote_server_options(matches: &clap::ArgMatches) -> Result<Option<Sources>> 
     Ok(sources)
 }
 
-#[derive(Deserialize, Debug, Clone, Default)]
+#[derive(Deserialize, Debug, Clone, Default, PartialEq)]
 pub enum PolicyMode {
     #[serde(rename = "monitor")]
     Monitor,
@@ -312,7 +312,7 @@ pub enum PolicyOrPolicyGroupSettings {
 }
 
 /// `PolicyGroupMember` represents a single policy that is part of a policy group.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct PolicyGroupMember {
     /// Thge URL where the policy is located
@@ -332,7 +332,7 @@ impl PolicyGroupMember {
 }
 
 /// Describes a policy that can be either an individual policy or a group policy.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum PolicyOrPolicyGroup {
     /// An individual policy
@@ -434,6 +434,89 @@ mod tests {
     use serde_json::json;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn read_policies_file_test() {
+        let policies_yaml = r#"
+---
+example:
+    url: ghcr.io/kubewarden/policies/context-aware-policy:0.1.0
+    settings: {}
+    allowedToMutate: true
+    contextAwareResources:
+        - apiVersion: v1
+          kind: Namespace
+        - apiVersion: v1
+          kind: Pod
+group_policy:
+    policyMode: monitor
+    expression: "true"
+    message: "group policy message"
+    policies:
+        policy1:
+            url: ghcr.io/kubewarden/policies/policy1:0.1.0
+            settings: {}
+        policy2:
+            url: ghcr.io/kubewarden/policies/policy2:0.1.0
+            settings: {}
+"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(policies_yaml.as_bytes()).unwrap();
+        let file_path = temp_file.into_temp_path();
+
+        let policies = read_policies_file(file_path.as_ref()).unwrap();
+
+        let expected_policies = HashMap::from([
+            (
+                "example".to_owned(),
+                PolicyOrPolicyGroup::Policy {
+                    url: "ghcr.io/kubewarden/policies/context-aware-policy:0.1.0".to_owned(),
+                    policy_mode: PolicyMode::Protect,
+                    allowed_to_mutate: Some(true),
+                    settings: Some(HashMap::new()),
+                    context_aware_resources: BTreeSet::from([
+                        ContextAwareResource {
+                            api_version: "v1".to_owned(),
+                            kind: "Namespace".to_owned(),
+                        },
+                        ContextAwareResource {
+                            api_version: "v1".to_owned(),
+                            kind: "Pod".to_owned(),
+                        },
+                    ]),
+                },
+            ),
+            (
+                "group_policy".to_owned(),
+                PolicyOrPolicyGroup::PolicyGroup {
+                    policy_mode: PolicyMode::Monitor,
+                    expression: "true".to_owned(),
+                    message: "group policy message".to_owned(),
+                    policies: HashMap::from([
+                        (
+                            "policy1".to_owned(),
+                            PolicyGroupMember {
+                                url: "ghcr.io/kubewarden/policies/policy1:0.1.0".to_owned(),
+                                settings: Some(HashMap::new()),
+                                context_aware_resources: BTreeSet::new(),
+                            },
+                        ),
+                        (
+                            "policy2".to_string(),
+                            PolicyGroupMember {
+                                url: "ghcr.io/kubewarden/policies/policy2:0.1.0".to_owned(),
+                                settings: Some(HashMap::new()),
+                                context_aware_resources: BTreeSet::new(),
+                            },
+                        ),
+                    ]),
+                },
+            ),
+        ]);
+
+        assert_eq!(expected_policies, policies);
+    }
 
     #[rstest]
     #[case::settings_empty(

--- a/src/config.rs
+++ b/src/config.rs
@@ -333,9 +333,10 @@ impl PolicyGroupMember {
 
 /// Describes a policy that can be either an individual policy or a group policy.
 #[derive(Deserialize, Debug, Clone)]
-#[serde(untagged, rename_all = "camelCase")]
+#[serde(untagged)]
 pub enum PolicyOrPolicyGroup {
     /// An individual policy
+    #[serde(rename_all = "camelCase")]
     Policy {
         /// The URL where the policy is located
         url: String,
@@ -351,6 +352,7 @@ pub enum PolicyOrPolicyGroup {
         context_aware_resources: BTreeSet<ContextAwareResource>,
     },
     /// A group of policies that are evaluated together using a given expression
+    #[serde(rename_all = "camelCase")]
     PolicyGroup {
         /// The mode of the policy
         #[serde(default)]


### PR DESCRIPTION
## Description

Due to the recent addition of policy groups, the parsing of policies.yml was broken.
This happened because of [a pretty confusing serde behavior](https://github.com/serde-rs/json/issues/501), as an attribute on an enum is renaming all the variants of the enum, not all the fields of those variants.

TODO:
- [x] update tests
