### PR TITLE
fix: call set_meter_provider 

### DIFF
--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "16686:16686"
       - "4318:4317"
   otel-collector:
-    image: otel/opentelemetry-collector:0.98.0
+    image: otel/opentelemetry-collector:0.103.0
     volumes:
       - ./otel-collector-minimal-config.yml:/etc/otel-collector-config.yml
     ports:


### PR DESCRIPTION
## Description

Fixes: #847 

`opentelemetry-otlp` v.0.17.0 [introduces a breaking change](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/CHANGELOG.md), we need to call `global::set_meter_provider(meter_provider.clone());.` after building the metric provider. 

This PR fixes it.

We tested it locally with the dev tracing/metrics `docker-compose` and it seems to fix the issue.