### PR TITLE
fix: properly configure rustls stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -3972,6 +3972,7 @@ dependencies = [
  "reqwest",
  "rhai",
  "rstest",
+ "rustls",
  "rustls-pki-types",
  "semver",
  "serde",
@@ -4191,7 +4192,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -4224,7 +4225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -4237,7 +4238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.72",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ opentelemetry = { version = "0.24.0", default-features = false, features = [
 opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio"] }
 pprof = { version = "0.13", features = ["prost-codec"] }
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.4" }
+rustls = { version = "0.23" }
 rustls-pki-types = { version = "1", features = ["alloc"] }
 rayon = "1.10"
 regex = "1.10"
@@ -45,7 +46,7 @@ tracing-subscriber = { version = "0.3", features = ["ansi", "fmt", "json"] }
 semver = { version = "1.0.22", features = ["serde"] }
 mockall_double = "0.3"
 axum = { version = "0.7.5", features = ["macros", "query"] }
-axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
+axum-server = { version = "0.7.1", features = ["tls-rustls"] }
 tower-http = { version = "0.5.2", features = ["trace"] }
 tikv-jemallocator = { version = "0.5.4", features = [
   "profiling",
@@ -65,7 +66,7 @@ rstest = "0.22"
 tempfile = "3.12.0"
 tower = { version = "0.4", features = ["util"] }
 http-body-util = "0.1.1"
-testcontainers = { version = "0.21.1", features = ["watchdog"] }
+testcontainers = { version = "0.21", features = ["watchdog"] }
 backon = "0.4.4"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,12 @@ opentelemetry = { version = "0.24.0", default-features = false, features = [
 opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio"] }
 pprof = { version = "0.13", features = ["prost-codec"] }
 policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.4" }
-rustls = { version = "0.23" }
+rustls = { version = "0.23", default-features = false, features = [
+  "ring",
+  "logging",
+  "std",
+  "tls12",
+] }
 rustls-pki-types = { version = "1", features = ["alloc"] }
 rayon = "1.10"
 regex = "1.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,12 @@ use policy_server::PolicyServer;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Starting from rustls 0.22, each application must set its default crypto provider.
+    let crypto_provider = rustls::crypto::aws_lc_rs::default_provider();
+    crypto_provider
+        .install_default()
+        .expect("Failed to install crypto provider");
+
     let matches = cli::build_cli().get_matches();
     let config = policy_server::config::Config::from_args(&matches)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use policy_server::PolicyServer;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Starting from rustls 0.22, each application must set its default crypto provider.
-    let crypto_provider = rustls::crypto::aws_lc_rs::default_provider();
+    let crypto_provider = rustls::crypto::ring::default_provider();
     crypto_provider
         .install_default()
         .expect("Failed to install crypto provider");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -637,6 +637,15 @@ mod certificate_reload_helpers {
 async fn test_detect_certificate_rotation() {
     use certificate_reload_helpers::*;
 
+    // Starting from rustls 0.22, each application must set its default crypto provider.
+    // This setup is done inside of the `main` function of the policy server,
+    // which is not called in this test.
+    // Hence we have to setup the crypto provider here.
+    let crypto_provider = rustls::crypto::aws_lc_rs::default_provider();
+    crypto_provider
+        .install_default()
+        .expect("Failed to install crypto provider");
+
     let certs_dir = tempfile::tempdir().unwrap();
     let cert_file = certs_dir.path().join("policy-server.pem");
     let key_file = certs_dir.path().join("policy-server-key.pem");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -641,7 +641,7 @@ async fn test_detect_certificate_rotation() {
     // This setup is done inside of the `main` function of the policy server,
     // which is not called in this test.
     // Hence we have to setup the crypto provider here.
-    let crypto_provider = rustls::crypto::aws_lc_rs::default_provider();
+    let crypto_provider = rustls::crypto::ring::default_provider();
     crypto_provider
         .install_default()
         .expect("Failed to install crypto provider");


### PR DESCRIPTION
Starting from the 0.22 release, rustls requires each application to configure its default crypto provider. Without that, the application will face a runtime panic.

This is something the "cert-reload" integration test allowed us to expose.
