### PR TITLE
fix(ci): container build permissions in release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       id-token: write
       packages: write
+      contents: read
 
   release:
     name: Create release


### PR DESCRIPTION
Adds the read access to the "contents" permission in the release
workflow. This is necessary to allow the workflow to run. Otherwise, the
release job will not start.

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>
