### PR TITLE
fix: revisit AdmissionResponse of policy groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.8#6a187818c02bfc8484f1737dabc95f9176f86f9a"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.19.0#51d891670b53b949df5dcdfd3c9f414ab0930079"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4083,8 +4083,8 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.18.8"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.18.8#6a187818c02bfc8484f1737dabc95f9176f86f9a"
+version = "0.19.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.19.0#51d891670b53b949df5dcdfd3c9f414ab0930079"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ opentelemetry = { version = "0.24.0", default-features = false, features = [
 ] }
 opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio"] }
 pprof = { version = "0.13", features = ["prost-codec"] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.18.8" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.19.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",
   "logging",

--- a/src/api/service.rs
+++ b/src/api/service.rs
@@ -160,6 +160,7 @@ fn validation_response_with_constraints(
                         status: Some(AdmissionResponseStatus {
                             message: Some(format!("Request rejected by policy {policy_id}. The policy attempted to mutate the request, but it is currently configured to not allow mutations.")),
                             code: None,
+                            ..Default::default()
                         }),
                         // if `allowed_to_mutate` is false, we are in a validating webhook. If we send a patch, k8s will fail because validating webhook do not expect this field
                         patch: None,
@@ -197,11 +198,13 @@ fn validation_response_with_constraints(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::build_admission_review_request;
-    use lazy_static::lazy_static;
-    use rstest::*;
-
     use super::*;
+
+    use crate::test_utils::build_admission_review_request;
+
+    use lazy_static::lazy_static;
+    use policy_evaluator::admission_response;
+    use rstest::*;
 
     lazy_static! {
         static ref POLICY_ID: PolicyID = PolicyID::Policy("policy-id".to_string());
@@ -293,7 +296,7 @@ mod tests {
                 AdmissionResponse {
                     allowed: true,
                     patch: Some("patch".to_string()),
-                    patch_type: Some("application/json-patch+json".to_string()),
+                    patch_type: Some(admission_response::PatchType::JSONPatch),
                     ..Default::default()
                 },
             ),
@@ -308,7 +311,7 @@ mod tests {
                 AdmissionResponse {
                     allowed: true,
                     patch: Some("patch".to_string()),
-                    patch_type: Some("application/json-patch+json".to_string()),
+                    patch_type: Some(admission_response::PatchType::JSONPatch),
                     ..Default::default()
                 },
             ),
@@ -331,7 +334,7 @@ mod tests {
                 AdmissionResponse {
                     allowed: true,
                     patch: Some("patch".to_string()),
-                    patch_type: Some("application/json-patch+json".to_string()),
+                    patch_type: Some(admission_response::PatchType::JSONPatch),
                     ..Default::default()
                 },
             ),
@@ -347,7 +350,7 @@ mod tests {
                 AdmissionResponse {
                     allowed: true,
                     patch: Some("patch".to_string()),
-                    patch_type: Some("application/json-patch+json".to_string()),
+                    patch_type: Some(admission_response::PatchType::JSONPatch),
                     ..Default::default()
                 },
             ),
@@ -378,6 +381,7 @@ mod tests {
                     status: Some(AdmissionResponseStatus {
                         message: Some("some rejection message".to_string()),
                         code: Some(500),
+                        ..Default::default()
                     }),
                     ..Default::default()
                 },
@@ -408,6 +412,7 @@ mod tests {
                     status: Some(AdmissionResponseStatus {
                         message: Some("some rejection message".to_string()),
                         code: Some(500),
+                        ..Default::default()
                     }),
                     ..Default::default()
                 },
@@ -431,14 +436,14 @@ mod tests {
                 AdmissionResponse {
                     allowed: true,
                     patch: Some("patch".to_string()),
-                    patch_type: Some("application/json-patch+json".to_string()),
+                    patch_type: Some(admission_response::PatchType::JSONPatch),
                     ..Default::default()
                 },
             ),
             AdmissionResponse {
                 allowed: true,
                 patch: Some("patch".to_string()),
-                patch_type: Some("application/json-patch+json".to_string()),
+                patch_type: Some(admission_response::PatchType::JSONPatch),
                 ..Default::default()
             },
             "Mutated request from a policy allowed to mutate should be accepted in protect mode"
@@ -452,7 +457,7 @@ mod tests {
                 AdmissionResponse {
                     allowed: true,
                     patch: Some("patch".to_string()),
-                    patch_type: Some("application/json-patch+json".to_string()),
+                    patch_type: Some(admission_response::PatchType::JSONPatch),
                     ..Default::default()
                 },
             ),
@@ -493,6 +498,7 @@ mod tests {
                     status: Some(AdmissionResponseStatus {
                         message: Some("some rejection message".to_string()),
                         code: Some(500),
+                        ..Default::default()
                     }),
                     ..Default::default()
                 },
@@ -502,6 +508,7 @@ mod tests {
                     status: Some(AdmissionResponseStatus {
                         message: Some("some rejection message".to_string()),
                         code: Some(500),
+                        ..Default::default()
                     }),
                     ..Default::default()
                 }, "Not accepted request from a policy allowed to mutate should be rejected in protect mode"
@@ -530,6 +537,7 @@ mod tests {
                     status: Some(AdmissionResponseStatus {
                         message: Some("some rejection message".to_string()),
                         code: Some(500),
+                        ..Default::default()
                     }),
                     ..Default::default()
                 },
@@ -539,6 +547,7 @@ mod tests {
                     status: Some(AdmissionResponseStatus {
                         message: Some("some rejection message".to_string()),
                         code: Some(500),
+                        ..Default::default()
                     }),
                     ..Default::default()
                 }, "Not accepted request from a policy not allowed to mutate should be rejected in protect mode"


### PR DESCRIPTION
The API Server puts some limitations on the warnings:

- they cannot exceed 256 characters
- the size of all the warnings cannot exceed 4096 characters
- they are returned as HTTP headers, hence not all characters are allowed

Because of these reasons, starting from now, we use the warning struct only to tell the user whether a member policy was evaluated or not. When it was evaluated we just tell the outcome (allow/reject).

The details of each policy evaluation are returned as part of the `AdmissionResponse.status.details.causes`.

Notes: the warning messages are always shown, regardless of the request being accepted or rejected.
The `AdmissionResponse.status.details.causes` are shown only when the request is rejected. `kubectl` shows them only when run with verbose major or equal to 4 (`-v4`).

Policy Server always shows the `causes` inside of its logs when running in `debug` mode.

The `causes` are always sent as part of the traces emitted by Policy Server.
