### PR TITLE
fix: make cert rotation detection more reliable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ tempfile = "3.12.0"
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1.1"
 testcontainers = { version = "0.22", features = ["watchdog"] }
-backon = { version = "1.1.0", features = ["tokio-sleep"] }
+backon = { version = "1.2", features = ["tokio-sleep"] }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 rcgen = { version = "0.13", features = ["crypto"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,11 +302,11 @@ async fn create_tls_config_and_watch_certificate_changes(
         inotify::Inotify::init().map_err(|e| anyhow!("Cannot initialize inotify: {e}"))?;
     let cert_watch = inotify
         .watches()
-        .add(cert_file.clone(), inotify::WatchMask::MODIFY)
+        .add(cert_file.clone(), inotify::WatchMask::CLOSE_WRITE)
         .map_err(|e| anyhow!("Cannot watch certificate file: {e}"))?;
     let key_watch = inotify
         .watches()
-        .add(key_file.clone(), inotify::WatchMask::MODIFY)
+        .add(key_file.clone(), inotify::WatchMask::CLOSE_WRITE)
         .map_err(|e| anyhow!("Cannot watch key file: {e}"))?;
 
     let buffer = [0; 1024];


### PR DESCRIPTION
When detecting certificate and key changes, rely on the proper inotify message.

We have to wait for the `CLOSE_WRITE` event to happen to be sure all the contents of the cert/key have been written and flushed to disk.

Otherwise there's the risk of loading some incomplete data, leading to a runtime panic.

This was detected thanks to a flaky test.
