### PR TITLE
chore(deps): update wasmtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ opentelemetry = { version = "0.26.0", default-features = false, features = [
 ] }
 opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio"] }
 pprof = { version = "0.13", features = ["prost-codec"] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.19.2" }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.19.3" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",
   "logging",


### PR DESCRIPTION
Use latest version of policy-evaluator. This is required to bump wasmtime dependencies
