### PR TITLE
feat: add otlp endpoint config and cli flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,7 +169,12 @@ pub(crate) fn build_cli() -> Command {
                 .long("continue-on-errors")
                 .env("KUBEWARDEN_CONTINUE_ON_ERRORS")
                 .action(ArgAction::SetTrue)
-                .hide(true)
+                .hide(true),
+            Arg::new("otlp-endpoint")
+                .long("otlp-endpoint")
+                .env("OTEL_EXPORTER_OTLP_ENDPOINT")
+                .default_value("http://localhost:4317")
+                .help("The OTLP gRPC endpoint for exporting traces and metrics.")
     ];
     args.sort_by(|a, b| a.get_id().cmp(b.get_id()));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,7 @@ pub struct Config {
     pub log_level: String,
     pub log_fmt: String,
     pub log_no_color: bool,
+    pub otlp_endpoint: Option<String>,
     pub daemon: bool,
     pub enable_pprof: bool,
     pub daemon_pid_file: String,
@@ -125,6 +126,9 @@ impl Config {
             .get_one::<bool>("log-no-color")
             .expect("clap should have assigned a default value")
             .to_owned();
+
+        let otlp_endpoint = matches.get_one::<String>("otlp-endpoint").cloned();
+
         let (cert_file, key_file) = tls_files(matches)?;
         let tls_config = if cert_file.is_empty() {
             None
@@ -160,6 +164,7 @@ impl Config {
             log_level,
             log_fmt,
             log_no_color,
+            otlp_endpoint,
             daemon,
             daemon_pid_file,
             daemon_stdout_file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,15 @@ async fn main() -> Result<()> {
     let matches = cli::build_cli().get_matches();
     let config = policy_server::config::Config::from_args(&matches)?;
 
-    setup_tracing(&config.log_level, &config.log_fmt, config.log_no_color)?;
+    setup_tracing(
+        &config.log_level,
+        &config.log_fmt,
+        config.log_no_color,
+        config.otlp_endpoint.as_deref(),
+    )?;
 
     if config.metrics_enabled {
-        setup_metrics()?;
+        setup_metrics(config.otlp_endpoint.as_deref())?;
     };
 
     if config.daemon {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -120,6 +120,7 @@ pub(crate) fn default_test_config() -> Config {
         log_level: "info".to_owned(),
         log_fmt: "json".to_owned(),
         log_no_color: false,
+        otlp_endpoint: None,
         daemon: false,
         daemon_pid_file: "policy_server.pid".to_owned(),
         daemon_stdout_file: None,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -773,7 +773,7 @@ async fn test_otel() {
             traces_output_file_path.to_str().unwrap(),
             "/tmp/traces.json",
         ))
-        .with_mapped_port(4317, 4317.into())
+        .with_mapped_port(1337, 4317.into())
         .with_cmd(vec!["--config=/etc/otel-collector-config.yaml"])
         .with_startup_timeout(Duration::from_secs(30))
         .start()
@@ -783,8 +783,15 @@ async fn test_otel() {
     let mut config = default_test_config();
     config.metrics_enabled = true;
     config.log_fmt = "otlp".to_string();
-    setup_metrics().unwrap();
-    setup_tracing(&config.log_level, &config.log_fmt, config.log_no_color).unwrap();
+    config.otlp_endpoint = Some("http://localhost:1337".to_string());
+    setup_metrics(config.otlp_endpoint.as_deref()).unwrap();
+    setup_tracing(
+        &config.log_level,
+        &config.log_fmt,
+        config.log_no_color,
+        config.otlp_endpoint.as_deref(),
+    )
+    .unwrap();
 
     let app = app(config).await;
 


### PR DESCRIPTION
## Description

This PR adds a new `--otlp-endpoint` flag and the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable, allowing users to specify a custom gRPC OTLP endpoint for exporting both metrics and traces.

Part of #993 

## Test

Updates existing integration tests.

