### PR TITLE
fix!: renames "url" field into "module".

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ This is an example of the policies file:
 
 ```yml
 psp-apparmor:
-  url: registry://ghcr.io/kubewarden/policies/psp-apparmor:v0.1.3
+  module: registry://ghcr.io/kubewarden/policies/psp-apparmor:v0.1.3
 psp-capabilities:
-  url: registry://ghcr.io/kubewarden/policies/psp-capabilities:v0.1.3
+  module: registry://ghcr.io/kubewarden/policies/psp-capabilities:v0.1.3
 namespace_simple:
-  url: file:///tmp/namespace-validate-policy.wasm
+  module: file:///tmp/namespace-validate-policy.wasm
   settings:
     valid_namespace: kubewarden-approved
 ```
@@ -98,7 +98,7 @@ This is an example of the policies file with a policy group:
 pod-image-signatures: # policy group
   policies:
     - name: sigstore_pgp
-      url: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
+      module: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
       settings:
         signatures:
           - image: "*"
@@ -106,14 +106,14 @@ pod-image-signatures: # policy group
               - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
               - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
     - name: sigstore_gh_action
-      url: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
+      module: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
       settings:
         signatures:
           - image: "*"
             githubActions:
             owner: "kubewarden"
     - name: reject_latest_tag
-      url: ghcr.io/kubewarden/policies/trusted-repos-policy:v0.1.12
+      module: ghcr.io/kubewarden/policies/trusted-repos-policy:v0.1.12
       settings:
         tags:
           reject:
@@ -133,7 +133,7 @@ that is allowed to access:
 strict-ingress-checks:
   policies:
     - name: unique_ingress
-      url: ghcr.io/kubewarden/policies/cel-policy:latest
+      module: ghcr.io/kubewarden/policies/cel-policy:latest
       contextAwareResources:
         - apiVersion: networking.k8s.io/v1
           kind: Ingress
@@ -154,13 +154,13 @@ strict-ingress-checks:
               !variables.knownHost.exists_one(hosts, sets.intersects(hosts, variables.desiredHosts))
             message: "Cannot reuse a host across multiple ingresses"
     - name: https_only
-      url: ghcr.io/kubewarden/policies/ingress:latest
+      module: ghcr.io/kubewarden/policies/ingress:latest
       settings:
         requireTLS: true
         allowPorts: [443]
         denyPorts: [80]
     - name: http_only
-      url: ghcr.io/kubewarden/policies/ingress:latest
+      module: ghcr.io/kubewarden/policies/ingress:latest
       settings:
         requireTLS: false
         allowPorts: [80]

--- a/policies.yml.example
+++ b/policies.yml.example
@@ -1,7 +1,7 @@
 psp-apparmor:
-  url: registry://ghcr.io/kubewarden/policies/psp-apparmor:v0.1.7
+  module: registry://ghcr.io/kubewarden/policies/psp-apparmor:v0.1.7
 psp-capabilities:
-  url: registry://ghcr.io/kubewarden/policies/psp-capabilities:v0.1.7
+  module: registry://ghcr.io/kubewarden/policies/psp-capabilities:v0.1.7
   allowedToMutate: true
   settings:
     allowed_capabilities: ["*"]
@@ -9,7 +9,7 @@ psp-capabilities:
 pod-image-signatures: # policy group
   policies:
     sigstore_pgp:
-      url: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
+      module: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
       settings:
         signatures:
           - image: "*"
@@ -17,14 +17,14 @@ pod-image-signatures: # policy group
               - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
               - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
     sigstore_gh_action:
-      url: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
+      module: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.8
       settings:
         signatures:
           - image: "*"
             githubActions:
             owner: "kubewarden"
     reject_latest_tag:
-      url: ghcr.io/kubewarden/policies/trusted-repos-policy:v0.1.12
+      module: ghcr.io/kubewarden/policies/trusted-repos-policy:v0.1.12
       settings:
         tags:
           reject:

--- a/src/config.rs
+++ b/src/config.rs
@@ -318,7 +318,7 @@ pub enum PolicyOrPolicyGroupSettings {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct PolicyGroupMember {
     /// Thge URL where the policy is located
-    pub url: String,
+    pub module: String,
     /// The settings for the policy
     pub settings: Option<HashMap<String, serde_yaml::Value>>,
     /// The list of Kubernetes resources the policy is allowed to access
@@ -341,7 +341,7 @@ pub enum PolicyOrPolicyGroup {
     #[serde(rename_all = "camelCase")]
     Policy {
         /// The URL where the policy is located
-        url: String,
+        module: String,
         #[serde(default)]
         /// The mode of the policy
         policy_mode: PolicyMode,
@@ -485,7 +485,7 @@ mod tests {
         let policies_yaml = r#"
 ---
 example:
-    url: ghcr.io/kubewarden/policies/context-aware-policy:0.1.0
+    module: ghcr.io/kubewarden/policies/context-aware-policy:0.1.0
     settings: {}
     allowedToMutate: true
     contextAwareResources:
@@ -499,10 +499,10 @@ group_policy:
     message: "group policy message"
     policies:
         policy1:
-            url: ghcr.io/kubewarden/policies/policy1:0.1.0
+            module: ghcr.io/kubewarden/policies/policy1:0.1.0
             settings: {}
         policy2:
-            url: ghcr.io/kubewarden/policies/policy2:0.1.0
+            module: ghcr.io/kubewarden/policies/policy2:0.1.0
             settings: {}
 "#;
 
@@ -516,7 +516,7 @@ group_policy:
             (
                 "example".to_owned(),
                 PolicyOrPolicyGroup::Policy {
-                    url: "ghcr.io/kubewarden/policies/context-aware-policy:0.1.0".to_owned(),
+                    module: "ghcr.io/kubewarden/policies/context-aware-policy:0.1.0".to_owned(),
                     policy_mode: PolicyMode::Protect,
                     allowed_to_mutate: Some(true),
                     settings: Some(HashMap::new()),
@@ -542,7 +542,7 @@ group_policy:
                         (
                             "policy1".to_owned(),
                             PolicyGroupMember {
-                                url: "ghcr.io/kubewarden/policies/policy1:0.1.0".to_owned(),
+                                module: "ghcr.io/kubewarden/policies/policy1:0.1.0".to_owned(),
                                 settings: Some(HashMap::new()),
                                 context_aware_resources: BTreeSet::new(),
                             },
@@ -550,7 +550,7 @@ group_policy:
                         (
                             "policy2".to_string(),
                             PolicyGroupMember {
-                                url: "ghcr.io/kubewarden/policies/policy2:0.1.0".to_owned(),
+                                module: "ghcr.io/kubewarden/policies/policy2:0.1.0".to_owned(),
                                 settings: Some(HashMap::new()),
                                 context_aware_resources: BTreeSet::new(),
                             },
@@ -568,7 +568,7 @@ group_policy:
         r#"
 ---
 example:
-  url: file:///tmp/namespace-validate-policy.wasm
+  module: file:///tmp/namespace-validate-policy.wasm
   settings: {}
 "#, json!({})
     )]
@@ -576,14 +576,14 @@ example:
         r#"
 ---
 example:
-  url: file:///tmp/namespace-validate-policy.wasm
+  module: file:///tmp/namespace-validate-policy.wasm
 "#, json!({})
     )]
     #[case::settings_null(
         r#"
 ---
 example:
-  url: file:///tmp/namespace-validate-policy.wasm
+  module: file:///tmp/namespace-validate-policy.wasm
   settings: null
 "#, json!({})
     )]
@@ -591,7 +591,7 @@ example:
         r#"
 ---
 example:
-  url: file:///tmp/namespace-validate-policy.wasm
+  module: file:///tmp/namespace-validate-policy.wasm
   settings:
     "counter": 1
     "items": ["a", "b"]
@@ -617,7 +617,7 @@ example:
         let policies_yaml = r#"
 ---
 example:
-  url: file:///tmp/namespace-validate-policy.wasm
+  module: file:///tmp/namespace-validate-policy.wasm
   settings: {}
 "#;
         let mut temp_file = NamedTempFile::new().unwrap();
@@ -654,17 +654,17 @@ example:
         r#"
 ---
 example:
-  url: file:///tmp/namespace-validate-policy.wasm
+  module: file:///tmp/namespace-validate-policy.wasm
   settings: {}
 group_policy:
   expression: "true"
   message: "group policy message"
   policies:
     policy1:
-      url: file:///tmp/namespace-validate-policy.wasm
+      module: file:///tmp/namespace-validate-policy.wasm
       settings: {}
     policy2:
-      url: file:///tmp/namespace-validate-policy.wasm
+      module: file:///tmp/namespace-validate-policy.wasm
       settings: {}
 "#,
         true
@@ -673,7 +673,7 @@ group_policy:
         r#"
 ---
 example/invalid:
-  url: file:///tmp/namespace-validate-policy.wasm
+  module: file:///tmp/namespace-validate-policy.wasm
   settings: {}
 "#,
         false
@@ -682,17 +682,17 @@ example/invalid:
         r#"
 ---
 example:
-  url: file:///tmp/namespace-validate-policy.wasm
+  module: file:///tmp/namespace-validate-policy.wasm
   settings: {}
 group_policy:
   expression: "true"
   message: "group policy message"
   policies:
     policy1/a:
-      url: file:///tmp/namespace-validate-policy.wasm
+      module: file:///tmp/namespace-validate-policy.wasm
       settings: {}
     policy2:
-      url: file:///tmp/namespace-validate-policy.wasm
+      module: file:///tmp/namespace-validate-policy.wasm
       settings: {}
 "#,
         false

--- a/src/evaluation/evaluation_environment.rs
+++ b/src/evaluation/evaluation_environment.rs
@@ -214,7 +214,7 @@ impl<'engine, 'precompiled_policies> EvaluationEnvironmentBuilder<'engine, 'prec
 
             match policy {
                 PolicyOrPolicyGroup::Policy {
-                    url,
+                    module: url,
                     policy_mode,
                     allowed_to_mutate,
                     context_aware_resources,
@@ -297,7 +297,7 @@ impl<'engine, 'precompiled_policies> EvaluationEnvironmentBuilder<'engine, 'prec
                         if let Err(e) = self.bootstrap_policy(
                             &mut eval_env,
                             policy_id.clone(),
-                            &policy.url,
+                            &policy.module,
                             policy_evaluation_settings,
                             eval_ctx,
                         ) {
@@ -820,7 +820,7 @@ mod tests {
             policies.insert(
                 policy_id.to_string(),
                 PolicyOrPolicyGroup::Policy {
-                    url: policy_url.clone(),
+                    module: policy_url.clone(),
                     policy_mode: PolicyMode::Protect,
                     allowed_to_mutate: None,
                     settings: None,
@@ -838,7 +838,7 @@ mod tests {
                 policies: vec![(
                     "happy_policy_1".to_string(),
                     PolicyGroupMember {
-                        url: "file:///tmp/happy_policy_1.wasm".to_string(),
+                        module: "file:///tmp/happy_policy_1.wasm".to_string(),
                         settings: None,
                         context_aware_resources: BTreeSet::new(),
                     },
@@ -865,7 +865,7 @@ mod tests {
                 policies: vec![(
                     "happy_policy_1".to_string(),
                     PolicyGroupMember {
-                        url: "file:///tmp/happy_policy_1.wasm".to_string(),
+                        module: "file:///tmp/happy_policy_1.wasm".to_string(),
                         settings: None,
                         context_aware_resources: BTreeSet::new(),
                     },
@@ -902,7 +902,7 @@ mod tests {
                 policies: vec![(
                     "happy_policy_1".to_string(),
                     PolicyGroupMember {
-                        url: "file:///tmp/happy_policy_1.wasm".to_string(),
+                        module: "file:///tmp/happy_policy_1.wasm".to_string(),
                         settings: None,
                         context_aware_resources: BTreeSet::new(),
                     },
@@ -921,7 +921,7 @@ mod tests {
                     (
                         "happy_policy_1".to_string(),
                         PolicyGroupMember {
-                            url: "file:///tmp/happy_policy_1.wasm".to_string(),
+                            module: "file:///tmp/happy_policy_1.wasm".to_string(),
                             settings: None,
                             context_aware_resources: BTreeSet::new(),
                         },
@@ -929,7 +929,7 @@ mod tests {
                     (
                         "unhappy_policy_1".to_string(),
                         PolicyGroupMember {
-                            url: "file:///tmp/unhappy_policy_1.wasm".to_string(),
+                            module: "file:///tmp/unhappy_policy_1.wasm".to_string(),
                             settings: None,
                             context_aware_resources: BTreeSet::new(),
                         },
@@ -937,7 +937,7 @@ mod tests {
                     (
                         "unhappy_policy_2".to_string(),
                         PolicyGroupMember {
-                            url: "file:///tmp/unhappy_policy_1.wasm".to_string(),
+                            module: "file:///tmp/unhappy_policy_1.wasm".to_string(),
                             settings: None,
                             context_aware_resources: BTreeSet::new(),
                         },
@@ -959,7 +959,7 @@ mod tests {
                     (
                         "happy_policy_1".to_string(),
                         PolicyGroupMember {
-                            url: "file:///tmp/happy_policy_1.wasm".to_string(),
+                            module: "file:///tmp/happy_policy_1.wasm".to_string(),
                             settings: None,
                             context_aware_resources: BTreeSet::new(),
                         },
@@ -967,7 +967,7 @@ mod tests {
                     (
                         "unhappy_policy_1".to_string(),
                         PolicyGroupMember {
-                            url: "file:///tmp/unhappy_policy_1.wasm".to_string(),
+                            module: "file:///tmp/unhappy_policy_1.wasm".to_string(),
                             settings: None,
                             context_aware_resources: BTreeSet::new(),
                         },
@@ -975,7 +975,7 @@ mod tests {
                     (
                         "unhappy_policy_2".to_string(),
                         PolicyGroupMember {
-                            url: "file:///tmp/unhappy_policy_1.wasm".to_string(),
+                            module: "file:///tmp/unhappy_policy_1.wasm".to_string(),
                             settings: None,
                             context_aware_resources: BTreeSet::new(),
                         },

--- a/src/policy_downloader.rs
+++ b/src/policy_downloader.rs
@@ -238,14 +238,14 @@ fn policies_to_download(
 
     for (name, policy) in policies {
         match policy {
-            PolicyOrPolicyGroup::Policy { url, .. } => {
+            PolicyOrPolicyGroup::Policy { module: url, .. } => {
                 flattened_policies.insert(name.to_owned(), url.to_owned());
             }
             PolicyOrPolicyGroup::PolicyGroup { policies, .. } => {
                 for (sub_policy_name, sub_policy) in policies {
                     flattened_policies.insert(
                         format!("{name}/#{sub_policy_name}"),
-                        sub_policy.url.to_owned(),
+                        sub_policy.module.to_owned(),
                     );
                 }
             }
@@ -291,9 +291,9 @@ mod tests {
 
         let policies_cfg = r#"
     pod-privileged:
-      url: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+      module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     another-pod-privileged:
-      url: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+      module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     "#;
 
         let policies: HashMap<String, PolicyOrPolicyGroup> =
@@ -335,7 +335,7 @@ mod tests {
 
         let policies_cfg = r#"
     pod-privileged:
-      url: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
+      module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.9
     "#;
 
         let policies: HashMap<String, PolicyOrPolicyGroup> =

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,7 +31,7 @@ pub(crate) fn default_test_config() -> Config {
         (
             "pod-privileged".to_owned(),
             PolicyOrPolicyGroup::Policy {
-                url: "ghcr.io/kubewarden/tests/pod-privileged:v0.2.1".to_owned(),
+                module: "ghcr.io/kubewarden/tests/pod-privileged:v0.2.1".to_owned(),
                 policy_mode: PolicyMode::Protect,
                 allowed_to_mutate: None,
                 settings: None,
@@ -41,7 +41,7 @@ pub(crate) fn default_test_config() -> Config {
         (
             "raw-mutation".to_owned(),
             PolicyOrPolicyGroup::Policy {
-                url: "ghcr.io/kubewarden/tests/raw-mutation-policy:v0.1.0".to_owned(),
+                module: "ghcr.io/kubewarden/tests/raw-mutation-policy:v0.1.0".to_owned(),
                 policy_mode: PolicyMode::Protect,
                 allowed_to_mutate: Some(true),
                 settings: Some(HashMap::from([
@@ -57,7 +57,7 @@ pub(crate) fn default_test_config() -> Config {
         (
             "sleep".to_owned(),
             PolicyOrPolicyGroup::Policy {
-                url: "ghcr.io/kubewarden/tests/sleeping-policy:v0.1.0".to_owned(),
+                module: "ghcr.io/kubewarden/tests/sleeping-policy:v0.1.0".to_owned(),
                 policy_mode: PolicyMode::Protect,
                 allowed_to_mutate: None,
                 settings: Some(HashMap::from([("sleepMilliseconds".to_owned(), 2.into())])),
@@ -73,7 +73,7 @@ pub(crate) fn default_test_config() -> Config {
                 policies: HashMap::from([(
                     "pod_privileged".to_string(),
                     PolicyGroupMember {
-                        url: "ghcr.io/kubewarden/tests/pod-privileged:v0.2.1".to_owned(),
+                        module: "ghcr.io/kubewarden/tests/pod-privileged:v0.2.1".to_owned(),
                         settings: None,
                         context_aware_resources: BTreeSet::new(),
                     },
@@ -89,7 +89,7 @@ pub(crate) fn default_test_config() -> Config {
                 policies: HashMap::from([(
                     "raw_mutation".to_string(),
                     PolicyGroupMember {
-                        url: "ghcr.io/kubewarden/tests/raw-mutation-policy:v0.1.0".to_owned(),
+                        module: "ghcr.io/kubewarden/tests/raw-mutation-policy:v0.1.0".to_owned(),
                         settings: Some(HashMap::from([
                             (
                                 "forbiddenResources".to_owned(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -466,7 +466,7 @@ async fn test_verified_policy() {
     config.policies = HashMap::from([(
         "pod-privileged".to_owned(),
         PolicyOrPolicyGroup::Policy {
-            url: "ghcr.io/kubewarden/tests/pod-privileged:v0.2.1".to_owned(),
+            module: "ghcr.io/kubewarden/tests/pod-privileged:v0.2.1".to_owned(),
             policy_mode: PolicyMode::Protect,
             allowed_to_mutate: None,
             settings: None,
@@ -498,7 +498,7 @@ async fn test_policy_with_invalid_settings() {
     config.policies.insert(
         "invalid_settings".to_owned(),
         PolicyOrPolicyGroup::Policy {
-            url: "ghcr.io/kubewarden/tests/sleeping-policy:v0.1.0".to_owned(),
+            module: "ghcr.io/kubewarden/tests/sleeping-policy:v0.1.0".to_owned(),
             policy_mode: PolicyMode::Protect,
             allowed_to_mutate: None,
             settings: Some(HashMap::from([(
@@ -546,7 +546,7 @@ async fn test_policy_with_wrong_url() {
     config.policies.insert(
         "wrong_url".to_owned(),
         PolicyOrPolicyGroup::Policy {
-            url: "ghcr.io/kubewarden/tests/not_existing:v0.1.0".to_owned(),
+            module: "ghcr.io/kubewarden/tests/not_existing:v0.1.0".to_owned(),
             policy_mode: PolicyMode::Protect,
             allowed_to_mutate: None,
             settings: None,


### PR DESCRIPTION
## Description

Renames the "url" field into "module". This makes the field name the same of the name used in the CRDs.

Fix #906 
