### PR TITLE
build(deps): update all jemalloc packages at the same time.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "github>kubewarden/github-actions//renovate-config/default"
+  ],
+  "packageRules": [
+    {
+      "description": "Update all jemalloc packages together",
+      "matchPackageNames": ["tikv-jemalloc-ctl", "jemalloc_pprof"]
+    }
   ]
 }


### PR DESCRIPTION
## Description

Updates the renovate bot configuration to instruct the bot to bump all the jemalloc related crates at the same time. Therefore, version conflicts in building the PR are avoided.


This tries to fix https://github.com/kubewarden/policy-server/pull/1032 https://github.com/kubewarden/policy-server/pull/1033 https://github.com/kubewarden/policy-server/pull/1034