### PR TITLE
fix: cargo install ignoring Cargo.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /usr/src/policy-server
 COPY ./ ./
 
 RUN cargo install cargo-auditable
-RUN cargo auditable install --target aarch64-unknown-linux-musl --path .
+RUN cargo auditable install --locked --target aarch64-unknown-linux-musl --path .
 
 FROM --platform=${BUILDPLATFORM} ghcr.io/cross-rs/x86_64-unknown-linux-musl:0.2.5 AS build-amd64
 ARG BUILDPLATFORM
@@ -32,7 +32,7 @@ WORKDIR /usr/src/policy-server
 COPY ./ ./
 
 RUN cargo install cargo-auditable
-RUN cargo auditable install --target x86_64-unknown-linux-musl --path .
+RUN cargo auditable install --locked --target x86_64-unknown-linux-musl --path .
 
 FROM --platform=$BUILDPLATFORM alpine:3.21.2 AS cfg
 RUN echo "policy-server:x:65533:65533::/tmp:/sbin/nologin" >> /etc/passwd


### PR DESCRIPTION
## Description

[By default, the `Cargo.lock` file that is included with the package will be ignored by `cargo install`.](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile)

Since the Dockerfile uses `cargo auditable install`, there were scenarios where the build regenerated `Cargo.lock` with updated dependencies.  

As a result, the CI passed while the Docker build failed (see [[GitHub Actions run](https://github.com/kubewarden/policy-server/actions/runs/12902609277/job/35976498867)](https://github.com/kubewarden/policy-server/actions/runs/12902609277/job/35976498867)).  

This PR updates the Dockerfile to add `--locked` to the `cargo auditable install` instruction, fixing the issue.
