### PR TITLE
feat(cli): generate CLI reference documentation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,18 @@ jobs:
           directory: coverage/integration-tests
           flags: integration-tests
           verbose: true
+
+  docs:
+    name: Update documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - run: |
+          make build-docs
+          if ! git diff --quiet cli-docs.md; then
+            echo "Changes detected in cli-docs.md. Please run `make build-docs` and commit the changes."
+            gh run cancel ${{ github.run_id }}
+          fi
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-markdown"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebc67e6266e14f8b31541c2f204724fa2ac7ad5c17d6f5908fbb92a60f42cff"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4377,6 +4386,7 @@ dependencies = [
  "axum-server",
  "backon",
  "clap",
+ "clap-markdown",
  "daemonize",
  "futures",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,9 +5503,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ jemalloc_pprof = "0.6.0"
 tikv-jemalloc-ctl = "0.6.0"
 rhai = { version = "1.19.0", features = ["sync"] }
 tonic = { version = "0.12.3" }
+clap-markdown = "0.1.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inotify = "0.11"

--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,7 @@ download-spdx-sbom-generator: bin
 .PHONY: sbom
 sbom:
 	./$(BINDIR)/spdx-sbom-generator -f json
+
+.PHONY:build-docs
+build-docs:
+	cargo run --release -- docs --output cli-docs.md

--- a/README.md
+++ b/README.md
@@ -373,3 +373,8 @@ in our Kubewarden docs.
 ## Changelog
 
 See [GitHub Releases content](https://github.com/kubewarden/policy-server/releases).
+
+# CLI documentation
+
+If you want a complete list of the available commands, you can read the 
+[cli-docs.md](./cli-docs.md) file.

--- a/cli-docs.md
+++ b/cli-docs.md
@@ -1,0 +1,94 @@
+# Command-Line Help for `policy-server`
+
+This document contains the help content for the `policy-server` command-line program.
+
+**Command Overview:**
+
+* [`policy-server`↴](#policy-server)
+* [`policy-server docs`↴](#policy-server-docs)
+
+## `policy-server`
+
+
+
+**Usage:** `policy-server [OPTIONS] [COMMAND]`
+
+###### **Subcommands:**
+
+* `docs` — Generates the markdown documentation for policy-server commands
+
+###### **Options:**
+
+* `--addr <BIND_ADDRESS>` — Bind against ADDRESS
+
+  Default value: `0.0.0.0`
+* `--always-accept-admission-reviews-on-namespace <NAMESPACE>` — Always accept AdmissionReviews that target the given namespace
+* `--cert-file <CERT_FILE>` — Path to an X.509 certificate file for HTTPS
+
+  Default value: ``
+* `--daemon` — If set, runs policy-server in detached mode as a daemon
+* `--daemon-pid-file <DAEMON-PID-FILE>` — Path to the PID file, used only when running in daemon mode
+
+  Default value: `policy-server.pid`
+* `--daemon-stderr-file <DAEMON-STDERR-FILE>` — Path to the file holding stderr, used only when running in daemon mode
+* `--daemon-stdout-file <DAEMON-STDOUT-FILE>` — Path to the file holding stdout, used only when running in daemon mode
+* `--disable-timeout-protection` — Disable policy timeout protection
+* `--docker-config-json-path <DOCKER_CONFIG>` — Path to a Docker config.json-like path. Can be used to indicate registry authentication details
+* `--enable-metrics` — Enable metrics
+* `--enable-pprof` — Enable pprof profiling
+* `--ignore-kubernetes-connection-failure` — Do not exit with an error if the Kubernetes connection fails. This will cause context-aware policies to break when there's no connection with Kubernetes.
+* `--key-file <KEY_FILE>` — Path to an X.509 private key file for HTTPS
+
+  Default value: ``
+* `--log-fmt <LOG_FMT>` — Log output format
+
+  Default value: `text`
+
+  Possible values: `text`, `json`, `otlp`
+
+* `--log-level <LOG_LEVEL>` — Log level
+
+  Default value: `info`
+
+  Possible values: `trace`, `debug`, `info`, `warn`, `error`
+
+* `--log-no-color` — Disable colored output for logs
+* `--policies <POLICIES_FILE>` — YAML file holding the policies to be loaded and their settings
+
+  Default value: `policies.yml`
+* `--policies-download-dir <POLICIES_DOWNLOAD_DIR>` — Download path for the policies
+
+  Default value: `.`
+* `--policy-timeout <MAXIMUM_EXECUTION_TIME_SECONDS>` — Interrupt policy evaluation after the given time
+
+  Default value: `2`
+* `--port <PORT>` — Listen on PORT
+
+  Default value: `3000`
+* `--sigstore-cache-dir <SIGSTORE_CACHE_DIR>` — Directory used to cache sigstore data
+
+  Default value: `sigstore-data`
+* `--sources-path <SOURCES_PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `--verification-path <VERIFICATION_CONFIG_PATH>` — YAML file holding verification information (URIs, keys, annotations...)
+* `--workers <WORKERS_NUMBER>` — Number of worker threads to create
+
+
+
+## `policy-server docs`
+
+Generates the markdown documentation for policy-server commands
+
+**Usage:** `policy-server docs --output <FILE>`
+
+###### **Options:**
+
+* `-o`, `--output <FILE>` — path where the documentation file will be stored
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -204,4 +204,16 @@ pub(crate) fn build_cli() -> Command {
         .about(crate_description!())
         .long_version(VERSION_AND_BUILTINS.as_str())
         .args(args)
+        .subcommand(
+            Command::new("docs")
+                .about("Generates the markdown documentation for policy-server commands")
+                .arg(
+                    Arg::new("output")
+                        .long("output")
+                        .short('o')
+                        .required(true)
+                        .value_name("FILE")
+                        .help("path where the documentation file will be stored"),
+                ),
+        )
 }


### PR DESCRIPTION
## Description

Adds the "docs" subcommand to allow the CLI reference documentation generation in markdown format.

Related to #810 
