### PR TITLE
feat: expose readiness probe over http

### DIFF
--- a/cli-docs.md
+++ b/cli-docs.md
@@ -68,6 +68,9 @@ This document contains the help content for the `policy-server` command-line pro
 * `--port <PORT>` — Listen on PORT
 
   Default value: `3000`
+* `--readiness-probe-port <READINESS_PROBE_PORT>` — Expose readiness endpoint on READINESS_PROBE_PORT
+
+  Default value: `3000`
 * `--sigstore-cache-dir <SIGSTORE_CACHE_DIR>` — Directory used to cache sigstore data
 
   Default value: `sigstore-data`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,13 @@ pub(crate) fn build_cli() -> Command {
             .env("KUBEWARDEN_PORT")
             .help("Listen on PORT"),
 
+        Arg::new("readiness-probe-port")
+            .long("readiness-probe-port")
+            .value_name("READINESS_PROBE_PORT")
+            .default_value("3000")
+            .env("KUBEWARDEN_READINESS_PROBE_PORT")
+            .help("Expose readiness endpoint on READINESS_PROBE_PORT"),
+
         Arg::new("workers")
             .long("workers")
             .value_name("WORKERS_NUMBER")

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ lazy_static! {
 
 pub struct Config {
     pub addr: SocketAddr,
+    pub readiness_probe_addr: SocketAddr,
     pub sources: Option<Sources>,
     pub policies: HashMap<String, PolicyOrPolicyGroup>,
     pub policies_download_dir: PathBuf,
@@ -60,6 +61,7 @@ impl Config {
     pub fn from_args(matches: &ArgMatches) -> Result<Self> {
         // init some variables based on the cli parameters
         let addr = api_bind_address(matches)?;
+        let readiness_probe_addr = readiness_probe_bind_address(matches)?;
 
         let policies = policies(matches)?;
         let policies_download_dir = matches
@@ -142,6 +144,7 @@ impl Config {
 
         Ok(Self {
             addr,
+            readiness_probe_addr,
             sources,
             policies,
             policies_download_dir,
@@ -171,6 +174,16 @@ fn api_bind_address(matches: &clap::ArgMatches) -> Result<SocketAddr> {
         "{}:{}",
         matches.get_one::<String>("address").unwrap(),
         matches.get_one::<String>("port").unwrap()
+    )
+    .parse()
+    .map_err(|e| anyhow!("error parsing arguments: {}", e))
+}
+
+fn readiness_probe_bind_address(matches: &clap::ArgMatches) -> Result<SocketAddr> {
+    format!(
+        "{}:{}",
+        matches.get_one::<String>("address").unwrap(),
+        matches.get_one::<String>("readiness-probe-port").unwrap()
     )
     .parse()
     .map_err(|e| anyhow!("error parsing arguments: {}", e))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -106,6 +106,7 @@ pub(crate) fn default_test_config() -> Config {
 
     Config {
         addr: SocketAddr::from(([127, 0, 0, 1], 3001)),
+        readiness_probe_addr: SocketAddr::from(([127, 0, 0, 1], 3002)),
         sources: None,
         policies,
         policies_download_dir: tempdir().unwrap().into_path(),


### PR DESCRIPTION
## Description
Fix: #1077

Splits the api and the readiness server in two axum servers running on different ports.
[tokio::Notify](https://docs.rs/tokio/latest/tokio/sync/struct.Notify.html) was used to start serving the readiness probe server right after the main API server.

