### PR TITLE
fix: TlsConfig and mTLS logic

### DIFF
--- a/cli-docs.md
+++ b/cli-docs.md
@@ -24,11 +24,7 @@ This document contains the help content for the `policy-server` command-line pro
   Default value: `0.0.0.0`
 * `--always-accept-admission-reviews-on-namespace <NAMESPACE>` — Always accept AdmissionReviews that target the given namespace
 * `--cert-file <CERT_FILE>` — Path to an X.509 certificate file for HTTPS
-
-  Default value: ``
 * `--client-ca-file <CLIENT_CA_FILE>` — Path to an CA certificate file that issued the client certificate. Required to enable mTLS
-
-  Default value: ``
 * `--daemon` — If set, runs policy-server in detached mode as a daemon
 * `--daemon-pid-file <DAEMON-PID-FILE>` — Path to the PID file, used only when running in daemon mode
 
@@ -41,8 +37,6 @@ This document contains the help content for the `policy-server` command-line pro
 * `--enable-pprof` — Enable pprof profiling
 * `--ignore-kubernetes-connection-failure` — Do not exit with an error if the Kubernetes connection fails. This will cause context-aware policies to break when there's no connection with Kubernetes.
 * `--key-file <KEY_FILE>` — Path to an X.509 private key file for HTTPS
-
-  Default value: ``
 * `--log-fmt <LOG_FMT>` — Log output format
 
   Default value: `text`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,21 +84,18 @@ pub(crate) fn build_cli() -> Command {
         Arg::new("cert-file")
             .long("cert-file")
             .value_name("CERT_FILE")
-            .default_value("")
             .env("KUBEWARDEN_CERT_FILE")
             .help("Path to an X.509 certificate file for HTTPS"),
 
         Arg::new("key-file")
             .long("key-file")
             .value_name("KEY_FILE")
-            .default_value("")
             .env("KUBEWARDEN_KEY_FILE")
             .help("Path to an X.509 private key file for HTTPS"),
 
         Arg::new("client-ca-file")
             .long("client-ca-file")
             .value_name("CLIENT_CA_FILE")
-            .default_value("")
             .env("KUBEWARDEN_CLIENT_CA_FILE")
             .help("Path to an CA certificate file that issued the client certificate. Required to enable mTLS"),
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,7 +54,7 @@ pub struct Config {
 pub struct TlsConfig {
     pub cert_file: String,
     pub key_file: String,
-    pub client_ca_cert_file: Option<String>,
+    pub client_ca_file: Option<String>,
 }
 
 impl Config {
@@ -192,13 +192,13 @@ fn readiness_probe_bind_address(matches: &clap::ArgMatches) -> Result<SocketAddr
 fn build_tls_config(matches: &clap::ArgMatches) -> Result<Option<TlsConfig>> {
     let cert_file = matches.get_one::<String>("cert-file").cloned();
     let key_file = matches.get_one::<String>("key-file").cloned();
-    let client_ca_cert_file = matches.get_one::<String>("client-ca-file").cloned();
+    let client_ca_file = matches.get_one::<String>("client-ca-file").cloned();
 
-    match (cert_file, key_file, &client_ca_cert_file) {
+    match (cert_file, key_file, &client_ca_file) {
         (Some(cert_file), Some(key_file), _) => Ok(Some(TlsConfig {
             cert_file,
             key_file,
-            client_ca_cert_file,
+            client_ca_file,
         })),
         // No TLS configuration provided
         (None, None, None) => Ok(None),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -688,7 +688,7 @@ async fn test_detect_certificate_rotation() {
     config.tls_config = Some(policy_server::config::TlsConfig {
         cert_file: cert_file.to_str().unwrap().to_owned(),
         key_file: key_file.to_str().unwrap().to_owned(),
-        client_ca_cert_file: Some(client_ca.to_str().unwrap().to_owned()),
+        client_ca_file: Some(client_ca.to_str().unwrap().to_owned()),
     });
     config.policies = HashMap::new();
 


### PR DESCRIPTION
## Description  

With the latest changes, `TlsConfig` was always set to `Some`, causing the policy server to attempt loading certificate files from the default CLI value, which was an empty string (`""`). As a result, the policy server failed to start.  

This PR introduces an additional validation step:  
1. If either the certificate or key is provided while the other is missing.
2. If neither a certificate nor a key is provided via flags, `TlsConfig` is set to `None`.  
3. If a client CA is specified but the certificate and key are missing, an error is raised.  

The rationale behind point 3 is that mTLS is only enabled when server certificates are configured.