### PR TITLE
chore(deps): update policy-evaluator

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,5 @@
+[formatting]
+align_entries  = true
+reorder_arrays = true
+reorder_keys   = true
+sort_keys      = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "burrego"
 version = "0.3.4"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.19.11#e9577caf16b5850ac6f70bbd8ac89df474a4c7eb"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.20.0#77e206cfa3609e7d7da78d8ee3945c9e9b2d8cee"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4225,8 +4225,8 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "policy-evaluator"
-version = "0.19.11"
-source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.19.11#e9577caf16b5850ac6f70bbd8ac89df474a4c7eb"
+version = "0.20.0"
+source = "git+https://github.com/kubewarden/policy-evaluator?tag=v0.20.0#77e206cfa3609e7d7da78d8ee3945c9e9b2d8cee"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4266,14 +4266,15 @@ dependencies = [
 
 [[package]]
 name = "policy-fetcher"
-version = "0.9.0"
-source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.9.0#ffc16c3f0c4400533c2130d44bdc46a3c7ede747"
+version = "0.10.0"
+source = "git+https://github.com/kubewarden/policy-fetcher?tag=v0.10.0#262b50ad0dd237118c48f232e81f5748b301d719"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "cfg-if",
  "directories",
  "docker_credential",
+ "futures",
  "lazy_static",
  "oci-client",
  "path-slash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,87 +1,87 @@
 [package]
-name = "policy-server"
-version = "1.21.1"
 authors = [
-  "Kubewarden Developers <kubewarden@suse.de>",
+  "Fabrizio Sestito <fabrizio.sestito@suse.com>",
   "Flavio Castelli <fcastelli@suse.com>",
+  "José Guilherme Vanz <jguilhermevanz@suse.com>",
+  "Kubewarden Developers <kubewarden@suse.de>",
   "Rafael Fernández López <rfernandezlopez@suse.com>",
   "Víctor Cuadrado Juan <vcuadradojuan@suse.de>",
-  "José Guilherme Vanz <jguilhermevanz@suse.com>",
-  "Fabrizio Sestito <fabrizio.sestito@suse.com>",
 ]
 edition = "2021"
+name = "policy-server"
+version = "1.21.1"
 
 [dependencies]
 anyhow = "1.0"
+axum = { version = "0.8.1", features = ["macros", "query"] }
+axum-server = { version = "0.7.1", features = ["tls-rustls"] }
 clap = { version = "4.5", features = ["cargo", "env"] }
+clap-markdown = "0.1.4"
 daemonize = "0.5"
 futures = "0.3"
 itertools = "0.14.0"
+jemalloc_pprof = "0.6.0"
 k8s-openapi = { version = "0.24.0", default-features = false, features = [
   "v1_30",
 ] }
 lazy_static = "1.4.0"
 mime = "0.3"
+mockall_double = "0.3"
 num_cpus = "1.16.0"
-opentelemetry-otlp = { version = "0.27.0", features = [
-  "metrics",
-  "tonic",
-  "tls",
-] }
 opentelemetry = { version = "0.27.0", default-features = false, features = [
   "metrics",
   "trace",
 ] }
+opentelemetry-otlp = { version = "0.27.0", features = [
+  "metrics",
+  "tls",
+  "tonic",
+] }
 opentelemetry_sdk = { version = "0.27.0", features = ["rt-tokio"] }
+policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.20.0" }
 pprof = { version = "0.14", features = ["prost-codec"] }
-policy-evaluator = { git = "https://github.com/kubewarden/policy-evaluator", tag = "v0.19.11" }
+rayon = "1.10"
+regex = "1.10"
+rhai = { version = "1.19.0", features = ["sync"] }
 rustls = { version = "0.23", default-features = false, features = [
-  "ring",
   "logging",
+  "ring",
   "std",
   "tls12",
 ] }
-rustls-pki-types = { version = "1", features = ["alloc"] }
 rustls-pemfile = "2.2.0"
-rayon = "1.10"
-regex = "1.10"
-serde_json = "1.0"
+rustls-pki-types = { version = "1", features = ["alloc"] }
+semver = { version = "1.0.22", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 serde_yaml = "0.9.34"
 sha2 = "0.10"
 thiserror = "2.0"
-tokio = { version = "^1.43.0", features = ["full"] }
-tracing = "0.1"
-tracing-opentelemetry = "0.28.0"
-tracing-subscriber = { version = "0.3", features = ["ansi", "fmt", "json"] }
-semver = { version = "1.0.22", features = ["serde"] }
-mockall_double = "0.3"
-axum = { version = "0.8.1", features = ["macros", "query"] }
-axum-server = { version = "0.7.1", features = ["tls-rustls"] }
-tower-http = { version = "0.6.1", features = ["trace"] }
+tikv-jemalloc-ctl = "0.6.0"
 tikv-jemallocator = { version = "0.6.0", features = [
   "profiling",
   "unprefixed_malloc_on_supported_platforms",
 ] }
-jemalloc_pprof = "0.6.0"
-tikv-jemalloc-ctl = "0.6.0"
-rhai = { version = "1.19.0", features = ["sync"] }
+tokio = { version = "^1.43.0", features = ["full"] }
 tonic = { version = "0.12.3" }
-clap-markdown = "0.1.4"
+tower-http = { version = "0.6.1", features = ["trace"] }
+tracing = "0.1"
+tracing-opentelemetry = "0.28.0"
+tracing-subscriber = { version = "0.3", features = ["ansi", "fmt", "json"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-inotify = "0.11"
+inotify      = "0.11"
 tokio-stream = "0.1.15"
 
 [dev-dependencies]
-mockall = "0.13"
-rstest = "0.24"
-tempfile = "3.16.0"
-tower = { version = "0.5", features = ["util"] }
+backon         = { version = "1.3", features = ["tokio-sleep"] }
 http-body-util = "0.1.1"
+mockall        = "0.13"
+rcgen          = { version = "0.13", features = ["crypto"] }
+rstest         = "0.24"
+tempfile       = "3.16.0"
 testcontainers = { version = "0.23", features = ["watchdog"] }
-backon = { version = "1.3", features = ["tokio-sleep"] }
-rcgen = { version = "0.13", features = ["crypto"] }
+tower          = { version = "0.5", features = ["util"] }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 openssl = "0.10"


### PR DESCRIPTION
This PR consumes latest version of policy-evaluator. I just wanted to make sure some of the changes done to its public API are not breaking anything in this repo. 

While at that, I've also added the usual taplo configuration to format our `Cargo.toml` file
