### PR TITLE
fix: clap cannot downcast CLI flags to PathBuf

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,12 +85,14 @@ pub(crate) fn build_cli() -> Command {
             .long("cert-file")
             .value_name("CERT_FILE")
             .env("KUBEWARDEN_CERT_FILE")
+            .value_parser(clap::builder::PathBufValueParser::new())
             .help("Path to an X.509 certificate file for HTTPS"),
 
         Arg::new("key-file")
             .long("key-file")
             .value_name("KEY_FILE")
             .env("KUBEWARDEN_KEY_FILE")
+            .value_parser(clap::builder::PathBufValueParser::new())
             .help("Path to an X.509 private key file for HTTPS"),
 
         Arg::new("client-ca-file")
@@ -98,6 +100,7 @@ pub(crate) fn build_cli() -> Command {
             .value_delimiter(',')
             .value_name("CLIENT_CA_FILE")
             .env("KUBEWARDEN_CLIENT_CA_FILE")
+            .value_parser(clap::builder::PathBufValueParser::new())
             .help("Path to an CA certificate file that issued the client certificate. Required to enable mTLS"),
 
         Arg::new("policies")


### PR DESCRIPTION
## Description

After the recent changes clap is not able to cast the CLI flags into PathBuf type. To fix that, we can configure the value parser when the Arg is created.

This is causing errors when running CI on Kubewarden controller main branch and https://github.com/kubewarden/kubewarden-controller/pull/1007

```console
KUBEWARDEN_CERT_FILE="tls.crt" KUBEWARDEN_KEY_FILE="tls.key" KUBEWARDEN_POLICIES_DOWNLOAD_DIR=/tmp KUBEWARDEN_POLICIES=policies.yml.example KUBEWARDEN_LOG_LEVEL=debug KUBEWARDEN_SIGSTORE_CACHE_DIR="/tmp/sigstore-data" KUBEWARDEN_ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE="kubewarden" KUBEWARDEN_CLIENT_CA_FILE="ca.crt" cargo run
thread 'main' panicked at src/config.rs:193:29:
Mismatch between definition and access of `cert-file`. Could not downcast to std::path::PathBuf, need to downcast to alloc::string::String

stack backtrace:
   0: rust_begin_unwind
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/panicking.rs:74:14
   2: clap_builder::parser::error::MatchesError::unwrap
             at /home/jvanz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.30/src/parser/error.rs:32:9
   3: clap_builder::parser::matches::arg_matches::ArgMatches::get_one
             at /home/jvanz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.30/src/parser/matches/arg_matches.rs:119:9
   4: policy_server::config::build_tls_config
             at ./src/config.rs:193:21
   5: policy_server::config::Config::from_args
```


## Test

```shell
KUBEWARDEN_CERT_FILE="tls.crt" KUBEWARDEN_KEY_FILE="tls.key" KUBEWARDEN_POLICIES_DOWNLOAD_DIR=/tmp KUBEWARDEN_POLICIES=policies.yml.example KUBEWARDEN_LOG_LEVEL=debug KUBEWARDEN_SIGSTORE_CACHE_DIR="/tmp/sigstore-data" KUBEWARDEN_ALWAYS_ACCEPT_ADMISSION_REVIEWS_ON_NAMESPACE="kubewarden" KUBEWARDEN_CLIENT_CA_FILE="ca.crt" cargo run
```
