### PR TITLE
ci: Add version-check job to check Cargo.toml on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,23 @@ jobs:
         with:
           command: check
 
+  version-check:
+    name: Check Cargo.toml version
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download source code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Check cargo file version
+        run: |
+          CARGO_VERSION=$(sed  -n 's,^version\s*= \"\(.*\)\",\1,p' Cargo.toml)
+          TAG_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//')
+
+          if [ "$CARGO_VERSION" != "$TAG_VERSION" ];then
+              echo "::error title=Invalid Cargo.toml version::Cargo.toml version does not match the tag version"
+              exit 1
+          fi
+
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -132,4 +149,3 @@ jobs:
             echo "Changes detected in cli-docs.md. Please run `make build-docs` and commit the changes."
             gh run cancel ${{ github.run_id }}
           fi
-


### PR DESCRIPTION

## Description

On release (when the CI workflow is triggered by a tag), check that the Cargo.toml `version` matches the tag.

This prevents releasing badly tagged or version-annotated images.

This is lifted from kwctl's CI.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
