### PR TITLE
fix: change default readiness probe port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,10 @@ COPY --from=cfg /etc/passwd /etc/passwd
 COPY --from=cfg /etc/group /etc/group
 COPY ./Cargo.lock /Cargo.lock
 USER 65533:65533
+# Default port, should be used when tls is not enabled
 EXPOSE 3000
+# Readiness probe port, always http
+EXPOSE 8081
+# To be used when tls is enabled
+EXPOSE 8443
 ENTRYPOINT ["/policy-server"]

--- a/cli-docs.md
+++ b/cli-docs.md
@@ -64,7 +64,7 @@ This document contains the help content for the `policy-server` command-line pro
   Default value: `3000`
 * `--readiness-probe-port <READINESS_PROBE_PORT>` — Expose readiness endpoint on READINESS_PROBE_PORT
 
-  Default value: `3000`
+  Default value: `8081`
 * `--sigstore-cache-dir <SIGSTORE_CACHE_DIR>` — Directory used to cache sigstore data
 
   Default value: `sigstore-data`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,7 +71,7 @@ pub(crate) fn build_cli() -> Command {
         Arg::new("readiness-probe-port")
             .long("readiness-probe-port")
             .value_name("READINESS_PROBE_PORT")
-            .default_value("3000")
+            .default_value("8081")
             .env("KUBEWARDEN_READINESS_PROBE_PORT")
             .help("Expose readiness endpoint on READINESS_PROBE_PORT"),
 


### PR DESCRIPTION
The default value used by by readiness probe http server must be different from the one used to expose the validation endpoints. Having the same port causes the process to fail because two webservers are trying to bind to the same port.

Port 3000 is still used by default to expose the actual validation endpoints, while port 8081 is used to expose the readiness probe endpoint.

By default the Policy Server does not enforce TLS on its main port, because of that using a default value of 8443 instead of 3000 would lead to some confusion (assuming https has to be used instead of http).

To be honest, this is not relevant for the Kubewarden stack, since the kubewarden-controller has always been tuning the PolicyServer deployment to use port 8443. This is more useful for developers and for users that run Policy Server outside of Kubernetes.

Fixes https://github.com/kubewarden/policy-server/issues/1117
