### PR TITLE
fix: removed the rustls=off filter directive, which was previously suppressing all TLS-related message

### DIFF
--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -26,7 +26,6 @@ pub fn setup_tracing(
         .add_directive("cranelift_wasm=off".parse().unwrap())
         .add_directive("h2=off".parse().unwrap())
         .add_directive("hyper=off".parse().unwrap())
-        .add_directive("rustls=off".parse().unwrap())
         .add_directive("regalloc=off".parse().unwrap())
         .add_directive("wasmtime_cranelift=off".parse().unwrap())
         .add_directive("wasmtime_jit=off".parse().unwrap());


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #1148 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
