### PR TITLE
fix: add missing rust toolchain targets.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,3 +2,4 @@
 channel    = "1.86.0"
 components = ["clippy", "rust-analyzer", "rustfmt"]
 profile    = "minimal"
+targets    = ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
## Description

Updates the rust-toolchain.toml file adding the missing targets which the policy server is build for.
