### PR TITLE
feat: custom error message support.

### DIFF
--- a/policies.yml.example
+++ b/policies.yml.example
@@ -3,6 +3,7 @@ psp-apparmor:
 psp-capabilities:
   module: registry://ghcr.io/kubewarden/policies/psp-capabilities:v0.1.7
   allowedToMutate: true
+  message: "My custom error message"
   settings:
     allowed_capabilities: ["*"]
     required_drop_capabilities: ["KILL"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,4 @@
+mod admission_response_handler;
 pub mod admission_review;
 mod api_error;
 pub(crate) mod handlers;

--- a/src/api/admission_response_handler.rs
+++ b/src/api/admission_response_handler.rs
@@ -1,0 +1,493 @@
+use policy_evaluator::admission_response::{
+    AdmissionResponse, AdmissionResponseStatus, StatusCause, StatusDetails,
+};
+use tracing::info;
+
+use crate::{config::PolicyMode, evaluation::PolicyID};
+
+/// Apply as series of mutation constrains to the admission response.
+///
+/// Current constraints are:
+/// - A policy might have tried to mutate while the policy-server
+///   configuration does not allow it to mutate
+/// - A policy might be running in "Monitor" mode, that always
+///   accepts the request (without mutation), logging the answer
+/// - A policy might have a custom rejection message that should be used instead of the error
+///   returned by the policy. The original error is added in the warnings list.
+pub(crate) struct AdmissionResponseHandler<'a> {
+    policy_id: &'a PolicyID,
+    policy_mode: &'a PolicyMode,
+    allowed_to_mutate: bool,
+    custom_rejection_message: Option<String>,
+}
+
+impl<'a> AdmissionResponseHandler<'a> {
+    pub(crate) fn new(
+        policy_id: &'a PolicyID,
+        policy_mode: &'a PolicyMode,
+        allowed_to_mutate: bool,
+        custom_rejection_message: Option<String>,
+    ) -> Self {
+        AdmissionResponseHandler {
+            policy_id,
+            policy_mode,
+            allowed_to_mutate,
+            custom_rejection_message,
+        }
+    }
+
+    pub(crate) fn process_response(
+        &'a self,
+        admission_response: AdmissionResponse,
+    ) -> AdmissionResponse {
+        let admission_response = self.apply_monitor_mode(admission_response);
+        let admission_response = self.apply_mutation_constraint(admission_response);
+
+        // Note: apply the custom rejection message as a last step, so that it can override
+        // any previous status message.
+        self.apply_custom_rejection_message(admission_response)
+    }
+
+    // In monitor mode we always accept the request, but log what would have been the decision of the
+    // policy. We also force mutating patches to be none. Status is also  overridden, as it's only taken into
+    // account when a request is rejected.
+    fn apply_monitor_mode(&'a self, admission_response: AdmissionResponse) -> AdmissionResponse {
+        if self.policy_mode != &PolicyMode::Monitor {
+            return admission_response;
+        }
+
+        info!(
+            policy_id = self.policy_id.to_string(),
+            allowed_to_mutate = self.allowed_to_mutate,
+            response = format!("{admission_response:?}").as_str(),
+            "policy evaluation (monitor mode)",
+        );
+        AdmissionResponse {
+            allowed: true,
+            patch_type: None,
+            patch: None,
+            status: None,
+            ..admission_response
+        }
+    }
+
+    /// This check is applied only when the policy is in `Protect` mode.
+    /// If the policy attempted to mutate the request, but it is currently configured to not allow mutations,
+    /// the request is rejected.
+    fn apply_mutation_constraint(
+        &'a self,
+        admission_response: AdmissionResponse,
+    ) -> AdmissionResponse {
+        if self.policy_mode != &PolicyMode::Protect {
+            return admission_response;
+        }
+
+        if self.allowed_to_mutate {
+            // If the policy is allowed to mutate, we don't need to do anything
+            return admission_response;
+        }
+
+        if admission_response.patch.is_none() {
+            // If the policy did not attempt to mutate, we don't need to do anything
+            return admission_response;
+        }
+
+        AdmissionResponse {
+            allowed: false,
+            status: Some(AdmissionResponseStatus {
+                message: Some(rejection_message_because_policy_is_not_allowed_to_mutate(
+                    self.policy_id,
+                )),
+                code: None,
+                ..Default::default()
+            }),
+            // if `allowed_to_mutate` is false, we are in a validating webhook.
+            // If we send a patch, k8s will fail because validating webhook do not expect this field
+            patch: None,
+            patch_type: None,
+            ..admission_response
+        }
+    }
+
+    /// This check is applied only when the admission response is not allowed.
+    ///
+    /// If the policy has a custom rejection message, it is applied to the
+    /// admission response status.
+    /// The original rejection message is added to the status details causes
+    /// to preserve the original error message.
+    fn apply_custom_rejection_message(
+        &'a self,
+        admission_response: AdmissionResponse,
+    ) -> AdmissionResponse {
+        if admission_response.allowed {
+            // If the policy is allowed, we don't need to do anything
+            return admission_response;
+        }
+
+        if self.custom_rejection_message.is_none() {
+            // If the policy does not have a custom rejection message,
+            // we don't need to do anything
+            return admission_response;
+        }
+
+        let status = admission_response.status.unwrap_or_default();
+        let original_rejection_message = status.message.unwrap_or_default();
+
+        let mut causes = status.details.clone().unwrap_or_default().causes;
+        causes.push(StatusCause {
+            message: Some(original_rejection_message),
+            ..Default::default()
+        });
+
+        AdmissionResponse {
+            status: Some(AdmissionResponseStatus {
+                message: self.custom_rejection_message.clone(),
+                details: Some(StatusDetails {
+                    causes,
+                    ..status.details.unwrap_or_default()
+                }),
+                ..status
+            }),
+            ..admission_response
+        }
+    }
+}
+
+fn rejection_message_because_policy_is_not_allowed_to_mutate(policy_id: &PolicyID) -> String {
+    format!(
+        "Request rejected by policy {}. The policy attempted to mutate the request, but it is currently configured to not allow mutations.",
+        policy_id
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use lazy_static::lazy_static;
+    use policy_evaluator::admission_response::{self, AdmissionResponse};
+    use rstest::rstest;
+
+    lazy_static! {
+        static ref POLICY_ID: PolicyID = PolicyID::Policy("policy-id".to_string());
+    }
+
+    const DEFAULT_REJECTION_MESSAGE: &str = "default rejection message";
+
+    struct RejectionDetails {
+        pub message: String,
+        pub cause: Option<String>,
+    }
+
+    impl Default for RejectionDetails {
+        fn default() -> Self {
+            RejectionDetails {
+                message: DEFAULT_REJECTION_MESSAGE.to_string(),
+                cause: None,
+            }
+        }
+    }
+
+    fn rejection_response(rejection_details: RejectionDetails) -> AdmissionResponse {
+        let response = AdmissionResponse {
+            allowed: false,
+            patch: None,
+            patch_type: None,
+            status: Some(AdmissionResponseStatus {
+                message: Some(rejection_details.message.clone()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        if rejection_details.cause.is_some() {
+            AdmissionResponse {
+                status: Some(AdmissionResponseStatus {
+                    message: Some(rejection_details.message),
+                    details: Some(StatusDetails {
+                        causes: vec![StatusCause {
+                            message: rejection_details.cause.clone(),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..response
+            }
+        } else {
+            response
+        }
+    }
+
+    fn accepted_response() -> AdmissionResponse {
+        AdmissionResponse {
+            allowed: true,
+            ..Default::default()
+        }
+    }
+
+    fn mutation_response() -> AdmissionResponse {
+        AdmissionResponse {
+            allowed: true,
+            patch: Some("patch".to_string()),
+            patch_type: Some(admission_response::PatchType::JSONPatch),
+            ..Default::default()
+        }
+    }
+
+    #[rstest]
+    #[case::monitor_mode_allowed_to_mutate_custom_rejection_message(AdmissionResponseHandler::new(
+        &POLICY_ID,
+        &PolicyMode::Monitor,
+        true,
+        Some("Custom rejection message".to_string()),
+    ) )]
+    #[case::monitor_mode_not_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            false,
+            Some("Custom rejection message".to_string()),
+        ),
+    )]
+    #[case::monitor_mode_not_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            false,
+            None,
+        ),
+    )]
+    #[case::monitor_mode_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            true,
+            None,
+        ),
+    )]
+    #[case::protect_mode_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            true,
+            Some("Custom rejection message".to_string()),
+        ),
+    )]
+    #[case::protect_mode_not_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            false,
+            Some("Custom rejection message".to_string()),
+        ),
+    )]
+    #[case::protect_mode_not_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            false,
+            None,
+        ),
+    )]
+    #[case::protect_mode_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            true,
+            None,
+        ),
+    )]
+    fn process_accepted_response(#[case] handler: AdmissionResponseHandler) {
+        let processed_response = handler.process_response(accepted_response());
+        assert_eq!(processed_response, accepted_response());
+    }
+
+    #[rstest]
+    #[case::monitor_mode_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            true,
+            Some("Custom rejection message".to_string()),
+        ),
+        accepted_response(),
+    )]
+    #[case::monitor_mode_not_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            false,
+            Some("Custom rejection message".to_string()),
+        ),
+        accepted_response(),
+    )]
+    #[case::monitor_mode_not_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            false,
+            None,
+        ),
+        accepted_response(),
+    )]
+    #[case::monitor_mode_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            true,
+            None,
+        ),
+        accepted_response(),
+    )]
+    #[case::protect_mode_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            true,
+            Some("Custom rejection message".to_string()),
+        ),
+        rejection_response(RejectionDetails{
+            message: "Custom rejection message".to_string(),
+            cause: Some(DEFAULT_REJECTION_MESSAGE.to_string()),
+        }),
+    )]
+    #[case::protect_mode_not_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            false,
+            Some("Custom rejection message".to_string()),
+        ),
+        rejection_response(RejectionDetails{
+            message: "Custom rejection message".to_string(),
+            cause: Some(DEFAULT_REJECTION_MESSAGE.to_string()),
+        }),
+    )]
+    #[case::protect_mode_not_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            false,
+            None,
+        ),
+        rejection_response(RejectionDetails::default()),
+    )]
+    #[case::protect_mode_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            true,
+            None,
+        ),
+        rejection_response(RejectionDetails::default()),
+    )]
+    fn process_rejected_response(
+        #[case] handler: AdmissionResponseHandler,
+        #[case] expected_response: AdmissionResponse,
+    ) {
+        let processed_response =
+            handler.process_response(rejection_response(RejectionDetails::default()));
+        assert_eq!(
+            processed_response, expected_response,
+            "Got: {:?} - expected: {:?}",
+            processed_response, expected_response
+        );
+    }
+
+    #[rstest]
+    #[case::monitor_mode_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            true,
+            Some("Custom rejection message".to_string()),
+        ),
+        accepted_response(),
+    )]
+    #[case::monitor_mode_not_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            false,
+            Some("Custom rejection message".to_string()),
+        ),
+        accepted_response(),
+    )]
+    #[case::monitor_mode_not_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            false,
+            None,
+        ),
+        accepted_response(),
+    )]
+    #[case::monitor_mode_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Monitor,
+            true,
+            None,
+        ),
+        accepted_response(),
+    )]
+    #[case::protect_mode_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            true,
+            Some("Custom rejection message".to_string()),
+        ),
+        mutation_response(),
+    )]
+    #[case::protect_mode_not_allowed_to_mutate_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            false,
+            Some("Custom rejection message".to_string()),
+        ),
+        rejection_response(
+            RejectionDetails {
+                message: "Custom rejection message".to_string(),
+                cause: Some(rejection_message_because_policy_is_not_allowed_to_mutate(&POLICY_ID)),
+            }
+        ),
+    )]
+    #[case::protect_mode_not_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            false,
+            None,
+        ),
+        rejection_response(
+            RejectionDetails {
+                message: rejection_message_because_policy_is_not_allowed_to_mutate(&POLICY_ID),
+                cause: None,
+            }
+        ),
+    )]
+    #[case::protect_mode_allowed_to_mutate_no_custom_rejection_message(
+        AdmissionResponseHandler::new(
+            &POLICY_ID,
+            &PolicyMode::Protect,
+            true,
+            None,
+        ),
+        mutation_response(),
+    )]
+    fn process_mutated_response(
+        #[case] handler: AdmissionResponseHandler,
+        #[case] expected_response: AdmissionResponse,
+    ) {
+        let processed_response = handler.process_response(mutation_response());
+        assert_eq!(
+            processed_response, expected_response,
+            "Got: {:?} - expected: {:?}",
+            processed_response, expected_response
+        );
+    }
+}

--- a/src/api/service.rs
+++ b/src/api/service.rs
@@ -113,9 +113,9 @@ pub(crate) fn evaluate(
             &policy_mode,
             allowed_to_mutate,
             custom_rejection_message,
-            vanilla_validation_response.clone(),
+            vanilla_validation_response,
         ),
-        RequestOrigin::Audit => vanilla_validation_response.clone(),
+        RequestOrigin::Audit => vanilla_validation_response,
     };
 
     match validate_request {
@@ -135,8 +135,6 @@ pub(crate) fn evaluate(
             metrics::add_policy_evaluation(&policy_evaluation_metric);
         }
         ValidateRequest::Raw(_) => {
-            let accepted = vanilla_validation_response.allowed;
-            let mutated = vanilla_validation_response.patch.is_some();
             let raw_policy_evaluation_metric = metrics::RawPolicyEvaluation {
                 policy_name: policy_id.to_string(),
                 policy_mode: policy_mode.into(),

--- a/src/api/service.rs
+++ b/src/api/service.rs
@@ -158,7 +158,7 @@ pub(crate) fn evaluate(
 //   configuration does not allow it to mutate
 // - A policy might be running in "Monitor" mode, that always
 //   accepts the request (without mutation), logging the answer
-// - A policy might have a custom error message that should be used instead of the error returned
+// - A policy might have a custom rejection message that should be used instead of the error returned
 //   by the policy. The original error is added in the warnings list.
 fn validation_response_with_constraints(
     policy_id: &PolicyID,

--- a/src/config.rs
+++ b/src/config.rs
@@ -376,6 +376,8 @@ pub enum PolicyOrPolicyGroup {
         #[serde(default)]
         /// The list of Kubernetes resources the policy is allowed to access
         context_aware_resources: BTreeSet<ContextAwareResource>,
+        /// The message that is returned when the policy evaluates to false
+        message: Option<String>,
     },
     /// A group of policies that are evaluated together using a given expression
     #[serde(rename_all = "camelCase")]
@@ -512,6 +514,7 @@ example:
     module: ghcr.io/kubewarden/policies/context-aware-policy:0.1.0
     settings: {}
     allowedToMutate: true
+    message: "my custom error message"
     contextAwareResources:
         - apiVersion: v1
           kind: Namespace
@@ -554,6 +557,7 @@ group_policy:
                             kind: "Pod".to_owned(),
                         },
                     ]),
+                    message: Some("my custom error message".to_owned()),
                 },
             ),
             (

--- a/src/evaluation/policy_evaluation_settings.rs
+++ b/src/evaluation/policy_evaluation_settings.rs
@@ -11,4 +11,6 @@ pub(crate) struct PolicyEvaluationSettings {
     pub(crate) allowed_to_mutate: bool,
     /// The policy-specific settings provided by the user
     pub(crate) settings: PolicyOrPolicyGroupSettings,
+    /// Determines a custom rejection message for the policy
+    pub(crate) custom_rejection_message: Option<String>,
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,6 +36,7 @@ pub(crate) fn default_test_config() -> Config {
                 allowed_to_mutate: None,
                 settings: None,
                 context_aware_resources: BTreeSet::new(),
+                message: None,
             },
         ),
         (
@@ -52,6 +53,7 @@ pub(crate) fn default_test_config() -> Config {
                     ("defaultResource".to_owned(), "hay".into()),
                 ])),
                 context_aware_resources: BTreeSet::new(),
+                message: None,
             },
         ),
         (
@@ -62,6 +64,7 @@ pub(crate) fn default_test_config() -> Config {
                 allowed_to_mutate: None,
                 settings: Some(HashMap::from([("sleepMilliseconds".to_owned(), 2.into())])),
                 context_aware_resources: BTreeSet::new(),
+                message: None,
             },
         ),
         (


### PR DESCRIPTION
## Description

Updates the policy server to allow user define a "message" field in the policies.yml file to customize the error message returned by the policy.

Fix #1190 
