### PR TITLE
chore: prepare for v1.26.0-rc1 release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "1.25.0"
+version = "1.26.0-rc1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 edition = "2021"
 name = "policy-server"
-version = "1.25.0"
+version = "1.26.0-rc1"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
## Description

Bump the version in Cargo files in preparation to the v1.26.0-rc1 release.
