### PR TITLE
feat: Support per-policy `timeout_eval_seconds` in the policy-server config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct Config {
     pub policies_download_dir: PathBuf,
     pub ignore_kubernetes_connection_failure: bool,
     pub always_accept_admission_reviews_on_namespace: Option<String>,
+    // This is the global timeout for each policy evaluation.
     pub policy_evaluation_limit_seconds: Option<u64>,
     pub tls_config: Option<TlsConfig>,
     pub pool_size: usize,
@@ -307,6 +308,8 @@ pub struct PolicyGroupMember {
     /// The list of Kubernetes resources the policy is allowed to access
     #[serde(default)]
     pub context_aware_resources: BTreeSet<ContextAwareResource>,
+    /// Timeout for the evaluation of the policy
+    pub timeout_eval_seconds: Option<u64>,
 }
 
 impl PolicyGroupMember {
@@ -338,6 +341,8 @@ pub enum PolicyOrPolicyGroup {
         context_aware_resources: BTreeSet<ContextAwareResource>,
         /// The message that is returned when the policy evaluates to false
         message: Option<String>,
+        /// Timeout for the evaluation of the policy
+        timeout_eval_seconds: Option<u64>,
     },
     /// A group of policies that are evaluated together using a given expression
     #[serde(rename_all = "camelCase")]
@@ -489,6 +494,7 @@ group_policy:
                         },
                     ]),
                     message: Some("my custom error message".to_owned()),
+                    timeout_eval_seconds: None,
                 },
             ),
             (
@@ -504,6 +510,7 @@ group_policy:
                                 module: "ghcr.io/kubewarden/policies/policy1:0.1.0".to_owned(),
                                 settings: Some(PolicySettings::default()),
                                 context_aware_resources: BTreeSet::new(),
+                                timeout_eval_seconds: None,
                             },
                         ),
                         (
@@ -512,6 +519,7 @@ group_policy:
                                 module: "ghcr.io/kubewarden/policies/policy2:0.1.0".to_owned(),
                                 settings: Some(PolicySettings::default()),
                                 context_aware_resources: BTreeSet::new(),
+                                timeout_eval_seconds: None,
                             },
                         ),
                     ]),

--- a/src/evaluation/policy_evaluation_settings.rs
+++ b/src/evaluation/policy_evaluation_settings.rs
@@ -14,4 +14,6 @@ pub(crate) struct PolicyEvaluationSettings {
     pub(crate) settings: PolicyOrPolicyGroupSettings,
     /// Determines a custom rejection message for the policy
     pub(crate) custom_rejection_message: Option<String>,
+    /// Timeout for the evaluation of the policy in seconds
+    pub(crate) timeout_eval_seconds: Option<u64>,
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -41,6 +41,7 @@ pub(crate) fn default_test_config() -> Config {
                 settings: None,
                 context_aware_resources: BTreeSet::new(),
                 message: None,
+                timeout_eval_seconds: None,
             },
         ),
         (
@@ -58,6 +59,7 @@ pub(crate) fn default_test_config() -> Config {
                 ),
                 context_aware_resources: BTreeSet::new(),
                 message: None,
+                timeout_eval_seconds: None,
             },
         ),
         (
@@ -66,6 +68,7 @@ pub(crate) fn default_test_config() -> Config {
                 module: "ghcr.io/kubewarden/tests/sleeping-policy:v0.1.0".to_owned(),
                 policy_mode: PolicyMode::Protect,
                 allowed_to_mutate: None,
+                timeout_eval_seconds: None,
                 settings: Some(
                     PolicySettings::try_from(&json!({
                         "sleepMilliseconds": 2
@@ -88,6 +91,7 @@ pub(crate) fn default_test_config() -> Config {
                         module: "ghcr.io/kubewarden/tests/pod-privileged:v0.2.1".to_owned(),
                         settings: None,
                         context_aware_resources: BTreeSet::new(),
+                        timeout_eval_seconds: None,
                     },
                 )]),
             },
@@ -110,6 +114,7 @@ pub(crate) fn default_test_config() -> Config {
                             .unwrap(),
                         ),
                         context_aware_resources: BTreeSet::new(),
+                        timeout_eval_seconds: None,
                     },
                 )]),
             },

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -119,6 +119,25 @@ pub(crate) fn default_test_config() -> Config {
                 )]),
             },
         ),
+        (
+            "sleep-1s-timeout".to_owned(),
+            PolicyOrPolicyGroup::Policy {
+                module: "ghcr.io/kubewarden/tests/sleeping-policy:v0.1.0".to_owned(),
+                policy_mode: PolicyMode::Protect,
+                allowed_to_mutate: None,
+                // This policy will sleep for 2 seconds but has a 1s timeout eval, so it should timeout
+                // regardless of the global timeout evaluation limit of the policy-server
+                timeout_eval_seconds: Some(1),
+                settings: Some(
+                    PolicySettings::try_from(&json!({
+                        "sleepMilliseconds": 2
+                    }))
+                    .unwrap(),
+                ),
+                context_aware_resources: BTreeSet::new(),
+                message: None,
+            },
+        ),
     ]);
 
     Config {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -81,6 +81,7 @@ async fn test_validate_custom_rejection_message() {
             settings: None,
             context_aware_resources: BTreeSet::new(),
             message: Some("Custom error message".to_owned()),
+            timeout_eval_seconds: None,
         },
     );
     let app = app(config).await;
@@ -513,6 +514,7 @@ async fn test_verified_policy() {
             settings: None,
             context_aware_resources: BTreeSet::new(),
             message: None,
+            timeout_eval_seconds: None,
         },
     )]);
     config.verification_config = Some(verification_config);
@@ -551,6 +553,7 @@ async fn test_policy_with_invalid_settings() {
             ),
             context_aware_resources: BTreeSet::new(),
             message: None,
+            timeout_eval_seconds: None,
         },
     );
     config.continue_on_errors = true;
@@ -597,6 +600,7 @@ async fn test_policy_with_wrong_url() {
             settings: None,
             context_aware_resources: BTreeSet::new(),
             message: None,
+            timeout_eval_seconds: None,
         },
     );
     config.continue_on_errors = true;


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/policy-server/issues/1226

Policies and PolicyGroups now accept an optional `timeout_eval_seconds` field
in the policies.yaml configuration file, which mirrors a `spec.timeoutEvalSeconds` field.
In the case of PolicyGroups, only the group members themselves
contain this new spec field.

In addition, if both a policy `timeout_eval_seconds` and a global policy-server `timeout_evaluation_seconds` is passed,
we propagate the policy one to the policy EvaluationBuilder.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->



## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added an integration test that checks that the policy timeout_eval_seconds is honoured and has precedence over the global policy-server one.

There's no easy way to add a unit test for the `EvaluationEnvironment::register()` to check that the new per-policy timeout_eval_seconds is honoured. This is because wasmtime doesn't expose the epoch_deadline value, so even if we modify policy-evaluator we would have no way to know besides doing a convoluted PolicyEvaluatorPreBuilder mock.
(this is also the reason why there are timeout integration tests already, see the integration test above the added one on this PR).

There's no need for test on the config.rs side, we would only test serde.


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
