### PR TITLE
ci: fix attestation generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,29 +138,38 @@ jobs:
             jq '.layers | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document")) | map(.digest) | join(" ")')
           echo "SBOM_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
 
+      # We need to upload provenance and SBOM files, plus their signatures under the GitHub Release page.
+      # Moreover, the files have to be named in a certain way.
+      # This is required by [ossf](https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases)
       - name: Download provenance and SBOM files
         run: |
           set -e
-          crane blob ghcr.io/${{github.repository_owner}}/policy-server@${{ env.PROVENANCE_DIGEST}} > policy-server-attestation-${{ matrix.arch }}-provenance.json
-          sha256sum policy-server-attestation-${{ matrix.arch }}-provenance.json >> policy-server-attestation-${{ matrix.arch }}-checksum.txt
+          crane blob ghcr.io/${{github.repository_owner}}/policy-server@${{ env.PROVENANCE_DIGEST}} \
+            > policy-server-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
 
+          crane blob ghcr.io/${{github.repository_owner}}/policy-server@${{ env.SBOM_DIGEST}} \
+            > policy-server-attestation-${{ matrix.arch }}-sbom.json
 
-          for sbom_digest in "${{ env.SBOM_DIGEST }}"; do
-            crane blob ghcr.io/${{github.repository_owner}}/policy-server@$sbom_digest > policy-server-attestation-${{ matrix.arch }}-sbom-${sbom_digest#"sha256:"}.json
-            sha256sum policy-server-attestation-${{ matrix.arch }}-sbom-${sbom_digest#"sha256:"}.json >> policy-server-attestation-${{ matrix.arch }}-checksum.txt
-          done
-
-      - name: Sign checksum file
+      - name: Sign provenance and SBOM files
         run: |
+          set -e
           cosign sign-blob --yes \
-            --bundle policy-server-attestation-${{ matrix.arch }}-checksum-cosign.bundle \
-            policy-server-attestation-${{ matrix.arch }}-checksum.txt
-            
+            --bundle policy-server-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
+            policy-server-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
           cosign verify-blob \
-            --bundle policy-server-attestation-${{ matrix.arch }}-checksum-cosign.bundle \
+            --bundle policy-server-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
             --certificate-identity="https://github.com/${{github.repository_owner}}/policy-server/.github/workflows/release.yml@${{ github.ref }}" \
-            policy-server-attestation-${{ matrix.arch }}-checksum.txt
+            policy-server-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
+
+          cosign sign-blob --yes \
+            --bundle policy-server-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
+            policy-server-attestation-${{ matrix.arch }}-sbom.json
+          cosign verify-blob \
+            --bundle policy-server-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity="https://github.com/${{github.repository_owner}}/policy-server/.github/workflows/release.yml@${{ github.ref }}" \
+            policy-server-attestation-${{ matrix.arch }}-sbom.json
 
       - name: Upload SBOMs as artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -244,8 +253,14 @@ jobs:
             let path = require('path');
 
             let files = [
-              'attestation-amd64.tar.gz',
-              'attestation-arm64.tar.gz',
+              'policy-server-attestation-amd64-provenance.intoto.jsonl',
+              'policy-server-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
+              'policy-server-attestation-arm64-provenance.intoto.jsonl',
+              'policy-server-attestation-arm64-provenance.intoto.jsonl.bundle.sigstore',
+              'policy-server-attestation-amd64-sbom.json',
+              'policy-server-attestation-amd64-sbom.json.bundle.sigstore',
+              'policy-server-attestation-arm64-sbom.json',
+              'policy-server-attestation-arm64-sbom.json.bundle.sigstore',
               'kubewarden-dashboard.json']
             const {RELEASE_ID} = process.env
 


### PR DESCRIPTION
Some components of the kubewarden project were failing at release time because of a change introduced by cosign v3.

Surprisingly, policy-server release would not have failed. That happened because its automation pipeline was NOT signing provenance and SBOM attestations.

This PR adopts the same approach used by the other components of the Kubewarden stack. It ensures the provenance and SBOM files are signed and are part of the GitHub Release as **individual** assets. The latter point is something required by openssf.
