### PR TITLE
fix(ci): add second cosign signature for compatibility

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -59,16 +59,23 @@ jobs:
           tags: |
             ghcr.io/${{github.repository_owner}}/policy-server:${{ env.TAG_NAME }}
 
-      - name: Sign container image
+      # We need to disable the new bundle format enabled by default since
+      # cosign v3.x.x because some verification tools (e.g. slsactl and old
+      # cosign) are not able to properly verify the signatures using this
+      # new format
+      - name: Sign container image with cosign v2 signature format
         run: |
-          # We need to disable the new bundle format enabled by default since
-          # cosign v3.x.x because some verification tools (e.g. slsactl and old
-          # cosign) are not able to properly verify the signatures using this
-          # new format
           cosign sign --yes --new-bundle-format=false --use-signing-config=false \
             ghcr.io/${{github.repository_owner}}/policy-server@${{ steps.build-image.outputs.digest }}
-            
-          cosign verify \
-            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-            --certificate-identity="https://github.com/${{github.repository_owner}}/policy-server/.github/workflows/container-build.yml@${{ github.ref }}" \
+
+      - name: Sign container image with cosign v3 signature format
+        run: |
+          cosign sign --yes --new-bundle-format=true --use-signing-config=true \
             ghcr.io/${{github.repository_owner}}/policy-server@${{ steps.build-image.outputs.digest }}
+
+      - name: Verify container image signature
+        run: |
+          cosign verify \
+          --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+          --certificate-identity="https://github.com/${{github.repository_owner}}/policy-server/.github/workflows/container-build.yml@${{ github.ref }}" \
+          ghcr.io/${{github.repository_owner}}/policy-server@${{ steps.build-image.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,15 +60,22 @@ jobs:
           tags: |
             ghcr.io/${{github.repository_owner}}/policy-server:${{ env.TAG_NAME }}
 
-      - name: Sign container image
+      # We need to disable the new bundle format enabled by default since
+      # cosign v3.x.x because some verification tools (e.g. slsactl and old
+      # cosign) are not able to properly verify the signatures using this
+      # new format
+      - name: Sign container image with cosign v2 signature format
         run: |
-          # We need to disable the new bundle format enabled by default since
-          # cosign v3.x.x because some verification tools (e.g. slsactl and old
-          # cosign) are not able to properly verify the signatures using this
-          # new format
           cosign sign --yes --new-bundle-format=false --use-signing-config=false \
             ghcr.io/${{github.repository_owner}}/policy-server@${{ steps.build-image.outputs.digest }}
-            
+
+      - name: Sign container image with cosign v3 signature format
+        run: |
+          cosign sign --yes --new-bundle-format=true --use-signing-config=true \
+            ghcr.io/${{github.repository_owner}}/policy-server@${{ steps.build-image.outputs.digest }}
+
+      - name: Verify container image signature
+        run: |
           cosign verify \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
             --certificate-identity="https://github.com/${{github.repository_owner}}/policy-server/.github/workflows/release.yml@${{ github.ref }}" \
@@ -158,22 +165,20 @@ jobs:
       - name: Sign provenance and SBOM files
         run: |
           set -e
-          # We need to disable the new bundle format enabled by default since
-          # cosign v3.x.x because some verification tools (e.g. slsactl and old
-          # cosign) are not able to properly verify the signatures using this
-          # new format
-          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+          cosign sign-blob --yes \
             --bundle policy-server-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
             policy-server-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
+
           cosign verify-blob \
             --bundle policy-server-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
             --certificate-identity="https://github.com/${{github.repository_owner}}/policy-server/.github/workflows/release.yml@${{ github.ref }}" \
             policy-server-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
 
-          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false \
+          cosign sign-blob --yes \
             --bundle policy-server-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
             policy-server-attestation-${{ matrix.arch }}-sbom.json
+
           cosign verify-blob \
             --bundle policy-server-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \


### PR DESCRIPTION
## Description

In order to allow old cosign version and other verification tools to verify the signature it's necessary to add a second signature using the old format. The default format before cosign v3 changed the default signature bundle.