### PR TITLE
chore: prepare 1.31.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "1.30.0"
+version = "1.30.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 edition = "2024"
 name = "policy-server"
-version = "1.30.0"
+version = "1.30.1"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
This is a patch release to address CVE-2025-64345
