### PR TITLE
chore: Bump policy-server version to v1.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "policy-server"
-version = "1.31.0-rc1"
+version = "1.31.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 edition = "2024"
 name = "policy-server"
-version = "1.31.0-rc1"
+version = "1.31.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Commit in preparation to release policy-server v1.31.0

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>
